### PR TITLE
[agent: claude] feat: queue.py — SQLite-backed TaskQueue with 10 unit tests

### DIFF
--- a/src/agent_crew/queue.py
+++ b/src/agent_crew/queue.py
@@ -1,0 +1,178 @@
+import json
+import sqlite3
+import time
+from typing import List, Optional
+
+from agent_crew.protocol import TaskRequest, TaskResult
+
+_ROLE_TO_TYPE = {
+    "coder": "implement",
+    "reviewer": "review",
+    "tester": "test",
+    "panel": "discuss",
+}
+
+_DDL = """
+CREATE TABLE IF NOT EXISTS tasks (
+    task_id     TEXT PRIMARY KEY,
+    task_type   TEXT NOT NULL,
+    description TEXT NOT NULL,
+    branch      TEXT NOT NULL DEFAULT '',
+    priority    INTEGER NOT NULL DEFAULT 3,
+    context     TEXT NOT NULL DEFAULT '{}',
+    status      TEXT NOT NULL DEFAULT 'pending',
+    created_at  REAL NOT NULL,
+    summary     TEXT,
+    verdict     TEXT,
+    findings    TEXT,
+    pr_number   INTEGER
+)
+"""
+
+
+class TaskQueue:
+    def __init__(self, db_path: str):
+        self._db_path = db_path
+        conn = self._connect()
+        conn.execute(_DDL)
+        conn.commit()
+        conn.close()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self._db_path, timeout=10, check_same_thread=False)
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def enqueue(self, task: TaskRequest) -> str:
+        conn = self._connect()
+        try:
+            conn.execute(
+                """
+                INSERT INTO tasks (task_id, task_type, description, branch, priority, context, status, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, 'pending', ?)
+                """,
+                (
+                    task.task_id,
+                    task.task_type,
+                    task.description,
+                    task.branch,
+                    task.priority,
+                    json.dumps(task.context),
+                    time.time(),
+                ),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        return task.task_id
+
+    def dequeue(self, agent: str = "", role: str = "") -> Optional[TaskRequest]:
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            task_type_filter = _ROLE_TO_TYPE.get(role) if role else None
+            if task_type_filter:
+                row = conn.execute(
+                    """
+                    SELECT * FROM tasks
+                    WHERE status = 'pending' AND task_type = ?
+                    ORDER BY priority ASC, created_at ASC
+                    LIMIT 1
+                    """,
+                    (task_type_filter,),
+                ).fetchone()
+            else:
+                row = conn.execute(
+                    """
+                    SELECT * FROM tasks
+                    WHERE status = 'pending'
+                    ORDER BY priority ASC, created_at ASC
+                    LIMIT 1
+                    """
+                ).fetchone()
+
+            if row is None:
+                conn.execute("ROLLBACK")
+                return None
+
+            conn.execute(
+                "UPDATE tasks SET status = 'in_progress' WHERE task_id = ?",
+                (row["task_id"],),
+            )
+            conn.execute("COMMIT")
+
+            return TaskRequest(
+                task_id=row["task_id"],
+                task_type=row["task_type"],
+                description=row["description"],
+                branch=row["branch"],
+                priority=row["priority"],
+                context=json.loads(row["context"]),
+            )
+        except Exception:
+            try:
+                conn.execute("ROLLBACK")
+            except Exception:
+                pass
+            raise
+        finally:
+            conn.close()
+
+    def submit_result(self, task_id: str, result: TaskResult) -> None:
+        conn = self._connect()
+        try:
+            row = conn.execute("SELECT task_id FROM tasks WHERE task_id = ?", (task_id,)).fetchone()
+            if row is None:
+                raise ValueError(f"Task not found: {task_id!r}")
+            conn.execute(
+                """
+                UPDATE tasks
+                SET status = 'completed', summary = ?, verdict = ?, findings = ?, pr_number = ?
+                WHERE task_id = ?
+                """,
+                (
+                    result.summary,
+                    result.verdict,
+                    json.dumps(result.findings),
+                    result.pr_number,
+                    task_id,
+                ),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def cancel(self, task_id: str) -> None:
+        conn = self._connect()
+        try:
+            conn.execute("UPDATE tasks SET status = 'cancelled' WHERE task_id = ?", (task_id,))
+            conn.commit()
+        finally:
+            conn.close()
+
+    def list_tasks(self, status: str = "") -> List[TaskRequest]:
+        conn = self._connect()
+        try:
+            if status:
+                rows = conn.execute(
+                    "SELECT * FROM tasks WHERE status = ? ORDER BY priority ASC, created_at ASC",
+                    (status,),
+                ).fetchall()
+            else:
+                rows = conn.execute(
+                    "SELECT * FROM tasks ORDER BY priority ASC, created_at ASC"
+                ).fetchall()
+            return [
+                TaskRequest(
+                    task_id=r["task_id"],
+                    task_type=r["task_type"],
+                    description=r["description"],
+                    branch=r["branch"],
+                    priority=r["priority"],
+                    context=json.loads(r["context"]),
+                )
+                for r in rows
+            ]
+        finally:
+            conn.close()

--- a/src/agent_crew/queue.py
+++ b/src/agent_crew/queue.py
@@ -125,6 +125,8 @@ class TaskQueue:
     def submit_result(self, task_id: str, result: TaskResult) -> None:
         conn = self._connect()
         try:
+            if result.task_id != task_id:
+                raise ValueError(f"task_id mismatch: argument {task_id!r} != result.task_id {result.task_id!r}")
             row = conn.execute("SELECT task_id FROM tasks WHERE task_id = ?", (task_id,)).fetchone()
             if row is None:
                 raise ValueError(f"Task not found: {task_id!r}")

--- a/src/agent_crew/queue.py
+++ b/src/agent_crew/queue.py
@@ -71,8 +71,11 @@ class TaskQueue:
         conn = self._connect()
         try:
             conn.execute("BEGIN IMMEDIATE")
-            task_type_filter = _ROLE_TO_TYPE.get(role) if role else None
-            if task_type_filter:
+            if role:
+                task_type_filter = _ROLE_TO_TYPE.get(role)
+                if task_type_filter is None:
+                    conn.execute("ROLLBACK")
+                    raise ValueError(f"Unknown role: {role!r}. Must be one of {list(_ROLE_TO_TYPE)}")
                 row = conn.execute(
                     """
                     SELECT * FROM tasks
@@ -128,10 +131,11 @@ class TaskQueue:
             conn.execute(
                 """
                 UPDATE tasks
-                SET status = 'completed', summary = ?, verdict = ?, findings = ?, pr_number = ?
+                SET status = ?, summary = ?, verdict = ?, findings = ?, pr_number = ?
                 WHERE task_id = ?
                 """,
                 (
+                    result.status,
                     result.summary,
                     result.verdict,
                     json.dumps(result.findings),

--- a/tests/unit/test_queue.py
+++ b/tests/unit/test_queue.py
@@ -136,6 +136,15 @@ def test_u_q08_submit_result_nonexistent(q):
         q.submit_result("ghost", res)
 
 
+# U-Q08b: Submit result where result.task_id != task_id argument → ValueError
+def test_u_q08b_submit_result_task_id_mismatch(q):
+    q.enqueue(make_task("t-001"))
+    q.dequeue()
+    res = TaskResult(task_id="other-id", status="completed", summary="mismatch")
+    with pytest.raises(ValueError, match="task_id mismatch"):
+        q.submit_result("t-001", res)
+
+
 # U-Q09: Cancel task → status=cancelled, dequeue 시 반환 안 됨
 def test_u_q09_cancel_task(q):
     q.enqueue(make_task())

--- a/tests/unit/test_queue.py
+++ b/tests/unit/test_queue.py
@@ -97,15 +97,20 @@ def test_u_q06_atomic_dequeue(db_path):
     assert len(task_ids) == 2
 
 
-# U-Q07: Submit result → status=completed, DB에서 실제로 읽어서 검증
-def test_u_q07_submit_result(q, tmp_path):
+# U-Q07: Submit result — completed/failed/needs_human 모두 DB에 올바르게 저장되는지 검증
+@pytest.mark.parametrize("result_status,verdict", [
+    ("completed", "approve"),
+    ("failed", None),
+    ("needs_human", None),
+])
+def test_u_q07_submit_result(q, result_status, verdict):
     q.enqueue(make_task())
     q.dequeue()
     res = TaskResult(
         task_id="t-001",
-        status="completed",
+        status=result_status,
         summary="Done",
-        verdict="approve",
+        verdict=verdict,
         findings=["f1"],
         pr_number=7,
     )
@@ -117,9 +122,9 @@ def test_u_q07_submit_result(q, tmp_path):
     row = conn.execute("SELECT * FROM tasks WHERE task_id = 't-001'").fetchone()
     conn.close()
 
-    assert row["status"] == "completed"
+    assert row["status"] == result_status
     assert row["summary"] == "Done"
-    assert row["verdict"] == "approve"
+    assert row["verdict"] == verdict
     assert json.loads(row["findings"]) == ["f1"]
     assert row["pr_number"] == 7
 

--- a/tests/unit/test_queue.py
+++ b/tests/unit/test_queue.py
@@ -1,0 +1,141 @@
+import threading
+
+import pytest
+
+from agent_crew.protocol import TaskRequest, TaskResult
+from agent_crew.queue import TaskQueue
+
+
+@pytest.fixture
+def q(tmp_path):
+    return TaskQueue(str(tmp_path / "test.db"))
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    return str(tmp_path / "shared.db")
+
+
+def make_task(task_id="t-001", task_type="implement", priority=3):
+    return TaskRequest(task_id=task_id, task_type=task_type, description="desc", priority=priority)
+
+
+# U-Q01: Enqueue single task → status=pending
+def test_u_q01_enqueue_returns_task_id(q):
+    task = make_task()
+    returned_id = q.enqueue(task)
+    assert returned_id == task.task_id
+    tasks = q.list_tasks(status="pending")
+    assert len(tasks) == 1
+    assert tasks[0].task_id == task.task_id
+
+
+# U-Q02: Priority ordering — priority=1 task가 priority=3보다 먼저 dequeue
+def test_u_q02_priority_ordering(q):
+    q.enqueue(make_task("low", priority=3))
+    q.enqueue(make_task("high", priority=1))
+    first = q.dequeue()
+    assert first is not None
+    assert first.task_id == "high"
+
+
+# U-Q03: Dequeue returns highest-priority pending task → status→in_progress
+def test_u_q03_dequeue_changes_status(q):
+    q.enqueue(make_task())
+    result = q.dequeue()
+    assert result is not None
+    assert result.task_id == "t-001"
+    pending = q.list_tasks(status="pending")
+    assert len(pending) == 0
+    in_progress = q.list_tasks(status="in_progress")
+    assert len(in_progress) == 1
+
+
+# U-Q04: Dequeue with role filter — task_type="review" 태스크만 반환
+def test_u_q04_dequeue_role_filter(q):
+    q.enqueue(make_task("impl", task_type="implement"))
+    q.enqueue(make_task("rev", task_type="review"))
+    result = q.dequeue(role="reviewer")
+    assert result is not None
+    assert result.task_id == "rev"
+    assert result.task_type == "review"
+
+
+# U-Q05: Dequeue empty queue → None
+def test_u_q05_dequeue_empty_returns_none(q):
+    result = q.dequeue()
+    assert result is None
+
+
+# U-Q06: Atomicity — 두 TaskQueue 인스턴스가 같은 DB에서 동시 dequeue 시 다른 task
+def test_u_q06_atomic_dequeue(db_path):
+    q1 = TaskQueue(db_path)
+    q2 = TaskQueue(db_path)
+    q1.enqueue(make_task("a", priority=1))
+    q1.enqueue(make_task("b", priority=2))
+
+    results = []
+    errors = []
+
+    def do_dequeue(queue):
+        try:
+            results.append(queue.dequeue())
+        except Exception as e:
+            errors.append(e)
+
+    t1 = threading.Thread(target=do_dequeue, args=(q1,))
+    t2 = threading.Thread(target=do_dequeue, args=(q2,))
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    assert not errors
+    task_ids = {r.task_id for r in results if r is not None}
+    assert len(task_ids) == 2
+
+
+# U-Q07: Submit result → status=completed, 결과 저장됨
+def test_u_q07_submit_result(q):
+    q.enqueue(make_task())
+    q.dequeue()
+    res = TaskResult(
+        task_id="t-001",
+        status="completed",
+        summary="Done",
+        verdict="approve",
+        findings=["f1"],
+        pr_number=7,
+    )
+    q.submit_result("t-001", res)
+    completed = q.list_tasks(status="completed")
+    assert len(completed) == 1
+
+
+# U-Q08: Submit result for nonexistent task_id → ValueError
+def test_u_q08_submit_result_nonexistent(q):
+    res = TaskResult(task_id="ghost", status="completed", summary="nope")
+    with pytest.raises(ValueError):
+        q.submit_result("ghost", res)
+
+
+# U-Q09: Cancel task → status=cancelled, dequeue 시 반환 안 됨
+def test_u_q09_cancel_task(q):
+    q.enqueue(make_task())
+    q.cancel("t-001")
+    cancelled = q.list_tasks(status="cancelled")
+    assert len(cancelled) == 1
+    result = q.dequeue()
+    assert result is None
+
+
+# U-Q10: List tasks by status filter
+def test_u_q10_list_tasks_by_status(q):
+    q.enqueue(make_task("a"))
+    q.enqueue(make_task("b"))
+    q.cancel("a")
+    pending = q.list_tasks(status="pending")
+    assert len(pending) == 1
+    assert pending[0].task_id == "b"
+    all_tasks = q.list_tasks()
+    assert len(all_tasks) == 2

--- a/tests/unit/test_queue.py
+++ b/tests/unit/test_queue.py
@@ -1,3 +1,5 @@
+import json
+import sqlite3
 import threading
 
 import pytest
@@ -95,8 +97,8 @@ def test_u_q06_atomic_dequeue(db_path):
     assert len(task_ids) == 2
 
 
-# U-Q07: Submit result → status=completed, 결과 저장됨
-def test_u_q07_submit_result(q):
+# U-Q07: Submit result → status=completed, DB에서 실제로 읽어서 검증
+def test_u_q07_submit_result(q, tmp_path):
     q.enqueue(make_task())
     q.dequeue()
     res = TaskResult(
@@ -108,8 +110,18 @@ def test_u_q07_submit_result(q):
         pr_number=7,
     )
     q.submit_result("t-001", res)
-    completed = q.list_tasks(status="completed")
-    assert len(completed) == 1
+
+    # DB에서 직접 읽어서 모든 필드 검증
+    conn = sqlite3.connect(q._db_path)
+    conn.row_factory = sqlite3.Row
+    row = conn.execute("SELECT * FROM tasks WHERE task_id = 't-001'").fetchone()
+    conn.close()
+
+    assert row["status"] == "completed"
+    assert row["summary"] == "Done"
+    assert row["verdict"] == "approve"
+    assert json.loads(row["findings"]) == ["f1"]
+    assert row["pr_number"] == 7
 
 
 # U-Q08: Submit result for nonexistent task_id → ValueError


### PR DESCRIPTION
Closes #2

## Summary
- SQLite-backed TaskQueue (enqueue/dequeue/cancel/submit_result/list_tasks)
- Atomic dequeue via BEGIN IMMEDIATE transaction (no double-assignment)
- Role-based filtering
- 10 unit tests passing (U-Q01~U-Q10)

## Test plan
- [ ] pytest tests/unit/test_queue.py — 10/10 pass