### PR TITLE
[agent: claude] Issue #17: E2E code-review loop with stub agents (E-LO01~E-LO04)

### DIFF
--- a/src/agent_crew/cli.py
+++ b/src/agent_crew/cli.py
@@ -207,11 +207,94 @@ def teardown(project: str, base: str):
 
 @crew.command("run")
 @click.argument("task")
-def run_cmd(task: str):
-    """Run TASK. TASK must not be empty."""
+@click.option("--db", default="", help="SQLite DB path (standalone)")
+@click.option("--project", default="", help="Project name (reads DB from state)")
+@click.option("--base", default=_DEFAULT_BASE, show_default=True)
+@click.option("--max-iter", default=0, type=int, help="Max review iterations (0 = default)")
+@click.option("--no-tester", is_flag=True, help="Skip test phase after approval")
+@click.option("--branch", default="main", show_default=True)
+def run_cmd(task: str, db: str, project: str, base: str,
+            max_iter: int, no_tester: bool, branch: str):
+    """Run TASK through the code-review loop."""
     if not task.strip():
         raise click.UsageError("task must not be empty")
-    click.echo(f"Running task: {task}")
+
+    if not db:
+        if not project:
+            raise click.ClickException("--db or --project is required")
+        state = _read_state(base, project)
+        if state is None:
+            raise click.ClickException(f"project {project!r} not found")
+        db = state["db"]
+
+    from agent_crew.loop import (
+        DEFAULT_MAX_ITER,
+        build_feedback,
+        enqueue_implement,
+        enqueue_review,
+        enqueue_test,
+        handle_review_result,
+        handle_test_result,
+    )
+    from agent_crew.queue import TaskQueue
+    import time
+
+    if max_iter <= 0:
+        max_iter = DEFAULT_MAX_ITER
+
+    queue = TaskQueue(db)
+
+    def _wait(task_id: str, timeout: float = 60.0):
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            result = queue.get_result(task_id)
+            if result is not None:
+                return result
+            time.sleep(0.1)
+        raise click.ClickException(f"task {task_id!r} timed out after {timeout}s")
+
+    impl_id = enqueue_implement(queue, task, branch)
+
+    for iteration in range(1, max_iter + 1):
+        _wait(impl_id)
+
+        review_id = enqueue_review(queue, task, branch, prev_task_id=impl_id)
+        review_result = _wait(review_id)
+
+        # pass no_tester=True here — test enqueue is handled manually below
+        outcome = handle_review_result(
+            review_result,
+            iteration=iteration,
+            max_iter=max_iter,
+            no_tester=True,
+            queue=queue,
+        )
+
+        if outcome == "escalate":
+            click.echo(f"Escalated after {max_iter} iterations.")
+            return
+
+        if outcome == "approved":
+            if not no_tester:
+                test_id = enqueue_test(queue, task, branch)
+                test_result = _wait(test_id)
+                test_outcome = handle_test_result(test_result)
+                if test_outcome == "passed":
+                    click.echo("Loop complete: approved and tested.")
+                else:
+                    click.echo(f"Tests {test_outcome}. Re-implementing.")
+                    impl_id = enqueue_implement(queue, task, branch,
+                                               context={"retry": True})
+                    continue
+            else:
+                click.echo("Loop complete: approved (no tester).")
+            return
+
+        # request_changes: re-implement with feedback
+        feedback = build_feedback(review_result)
+        impl_id = enqueue_implement(queue, task, branch, context={"feedback": feedback})
+
+    click.echo(f"Max iterations ({max_iter}) reached without approval.")
 
 
 @crew.command()

--- a/src/agent_crew/queue.py
+++ b/src/agent_crew/queue.py
@@ -251,3 +251,23 @@ class TaskQueue:
             ]
         finally:
             conn.close()
+
+    def get_result(self, task_id: str) -> Optional[TaskResult]:
+        """Return TaskResult if the task is done, else None."""
+        conn = self._connect()
+        try:
+            row = conn.execute(
+                "SELECT task_id, status, summary, verdict, findings FROM tasks WHERE task_id = ?",
+                (task_id,),
+            ).fetchone()
+            if row is None or row["status"] not in ("completed", "failed", "needs_human"):
+                return None
+            return TaskResult(
+                task_id=row["task_id"],
+                status=row["status"],
+                summary=row["summary"] or "",
+                verdict=row["verdict"],
+                findings=json.loads(row["findings"]) if row["findings"] else [],
+            )
+        finally:
+            conn.close()

--- a/tests/e2e/stubs/stub_agent.py
+++ b/tests/e2e/stubs/stub_agent.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""
+Stub agent for e2e tests.
+
+Environment variables:
+  STUB_PORT      TCP port of the task server (required)
+  STUB_ROLE      coder | reviewer | tester  (required)
+  STUB_VERDICT   approve | request_changes  (optional, only used by reviewer)
+  STUB_STATUS    completed | failed         (default: completed)
+  STUB_TIMEOUT   poll timeout in seconds    (default: 30)
+"""
+import json
+import os
+import sys
+import time
+import urllib.request
+
+PORT = int(os.environ["STUB_PORT"])
+ROLE = os.environ["STUB_ROLE"]
+VERDICT = os.environ.get("STUB_VERDICT", "") or None
+STATUS = os.environ.get("STUB_STATUS", "completed")
+TIMEOUT = float(os.environ.get("STUB_TIMEOUT", "30"))
+BASE_URL = f"http://127.0.0.1:{PORT}"
+
+
+def poll_task():
+    deadline = time.time() + TIMEOUT
+    while time.time() < deadline:
+        url = f"{BASE_URL}/tasks/next?role={ROLE}"
+        try:
+            with urllib.request.urlopen(url, timeout=2.0) as resp:
+                data = json.loads(resp.read())
+                if data is not None:
+                    return data
+        except Exception:
+            pass
+        time.sleep(0.1)
+    return None
+
+
+def submit_result(task_id):
+    result = {
+        "task_id": task_id,
+        "status": STATUS,
+        "summary": f"stub {ROLE} done",
+        "verdict": VERDICT,
+        "findings": [],
+    }
+    body = json.dumps(result).encode()
+    url = f"{BASE_URL}/tasks/{task_id}/result"
+    req = urllib.request.Request(
+        url, data=body, headers={"Content-Type": "application/json"}, method="POST"
+    )
+    with urllib.request.urlopen(req, timeout=5.0) as resp:
+        resp.read()
+
+
+task = poll_task()
+if task is None:
+    print(f"stub {ROLE}: no task found within {TIMEOUT}s", file=sys.stderr)
+    sys.exit(1)
+
+submit_result(task["task_id"])
+print(f"stub {ROLE}: submitted result for {task['task_id']}")

--- a/tests/e2e/test_e2e_loop.py
+++ b/tests/e2e/test_e2e_loop.py
@@ -1,0 +1,186 @@
+"""
+E2E tests for crew run CLI — full code-review loop with stub agents.
+
+E-LO01: crew run → stub coder → stub reviewer approves → stub tester passes → done
+E-LO02: reviewer requests changes once → 2 implement cycles → approved + tested
+E-LO03: crew run --max-iter 2, perpetual rejection → escalation gate after 2 iterations
+E-LO04: crew run --no-tester → no test task enqueued after approval
+"""
+
+import socket
+import threading
+import time
+
+import httpx
+import pytest
+import uvicorn
+from click.testing import CliRunner
+
+from agent_crew.cli import crew
+from agent_crew.queue import TaskQueue
+from agent_crew.server import create_app
+
+pytestmark = pytest.mark.e2e
+
+
+def _find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+@pytest.fixture
+def live_server(tmp_path):
+    """Start a real uvicorn server; yield (base_url, db_path); stop after test."""
+    db_path = str(tmp_path / "tasks.db")
+    port = _find_free_port()
+    app = create_app(db_path)
+
+    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="error")
+    server = uvicorn.Server(config)
+
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+
+    base_url = f"http://127.0.0.1:{port}"
+    deadline = time.time() + 10.0
+    while time.time() < deadline:
+        try:
+            httpx.get(f"{base_url}/tasks", timeout=0.5)
+            break
+        except Exception:
+            time.sleep(0.05)
+
+    yield base_url, db_path
+
+    server.should_exit = True
+    thread.join(timeout=5.0)
+
+
+def _stub_agent(base_url: str, role: str, verdict: str | None = None, poll_timeout: float = 30.0):
+    """Poll for one task of `role`, submit a completed result, then return."""
+    task = None
+    deadline = time.time() + poll_timeout
+    while time.time() < deadline:
+        resp = httpx.get(f"{base_url}/tasks/next", params={"role": role}, timeout=2.0)
+        if resp.status_code == 200 and resp.json() is not None:
+            task = resp.json()
+            break
+        time.sleep(0.05)
+
+    if task is None:
+        raise TimeoutError(f"stub {role} found no task within {poll_timeout}s")
+
+    result = {
+        "task_id": task["task_id"],
+        "status": "completed",
+        "summary": f"stub {role} done",
+        "verdict": verdict,
+        "findings": [],
+    }
+    httpx.post(f"{base_url}/tasks/{task['task_id']}/result", json=result, timeout=2.0)
+
+
+def _start_cli(args: list[str]):
+    """Invoke CLI in a daemon thread. Returns (thread, result_holder)."""
+    runner = CliRunner()
+    holder: list = [None]
+
+    def _run():
+        holder[0] = runner.invoke(crew, args)
+
+    t = threading.Thread(target=_run, daemon=True)
+    t.start()
+    return t, holder
+
+
+# E-LO01: basic happy path — coder done, reviewer approves, tester passes
+def test_e_lo01_basic_approve(live_server):
+    base_url, db_path = live_server
+
+    cli_t, holder = _start_cli(["run", "feat X", "--db", db_path, "--branch", "main"])
+
+    _stub_agent(base_url, "coder")
+    _stub_agent(base_url, "reviewer", verdict="approve")
+    _stub_agent(base_url, "tester")
+
+    cli_t.join(timeout=30.0)
+    assert not cli_t.is_alive(), "CLI thread timed out"
+
+    r = holder[0]
+    assert r.exit_code == 0, r.output
+    assert "approved" in r.output.lower()
+
+
+# E-LO02: reviewer requests changes once → 2 implement cycles → approved and tested
+def test_e_lo02_request_changes_then_approve(live_server):
+    base_url, db_path = live_server
+
+    cli_t, holder = _start_cli(["run", "feat Y", "--db", db_path, "--branch", "main"])
+
+    # iteration 1: coder done, reviewer rejects
+    _stub_agent(base_url, "coder")
+    _stub_agent(base_url, "reviewer", verdict="request_changes")
+    # iteration 2: coder done, reviewer approves, tester passes
+    _stub_agent(base_url, "coder")
+    _stub_agent(base_url, "reviewer", verdict="approve")
+    _stub_agent(base_url, "tester")
+
+    cli_t.join(timeout=60.0)
+    assert not cli_t.is_alive(), "CLI thread timed out"
+
+    r = holder[0]
+    assert r.exit_code == 0, r.output
+    assert "approved" in r.output.lower()
+
+
+# E-LO03: --max-iter 2, perpetual rejection → escalation gate created
+def test_e_lo03_escalation_gate(live_server):
+    base_url, db_path = live_server
+
+    cli_t, holder = _start_cli(
+        ["run", "feat Z", "--db", db_path, "--branch", "main", "--max-iter", "2"]
+    )
+
+    # iteration 1: coder done, reviewer rejects
+    _stub_agent(base_url, "coder")
+    _stub_agent(base_url, "reviewer", verdict="request_changes")
+    # iteration 2: coder done, reviewer rejects again → escalate
+    _stub_agent(base_url, "coder")
+    _stub_agent(base_url, "reviewer", verdict="request_changes")
+
+    cli_t.join(timeout=60.0)
+    assert not cli_t.is_alive(), "CLI thread timed out"
+
+    r = holder[0]
+    assert r.exit_code == 0, r.output
+    assert "escalated" in r.output.lower()
+
+    queue = TaskQueue(db_path)
+    gates = queue.list_gates()
+    assert len(gates) >= 1
+    assert gates[0].type == "escalation"
+
+
+# E-LO04: --no-tester → no test task is enqueued after approval
+def test_e_lo04_no_tester(live_server):
+    base_url, db_path = live_server
+
+    cli_t, holder = _start_cli(
+        ["run", "feat W", "--db", db_path, "--branch", "main", "--no-tester"]
+    )
+
+    _stub_agent(base_url, "coder")
+    _stub_agent(base_url, "reviewer", verdict="approve")
+
+    cli_t.join(timeout=30.0)
+    assert not cli_t.is_alive(), "CLI thread timed out"
+
+    r = holder[0]
+    assert r.exit_code == 0, r.output
+    assert "no tester" in r.output.lower()
+
+    queue = TaskQueue(db_path)
+    all_tasks = queue.list_tasks()
+    test_tasks = [t for t in all_tasks if t.task_type == "test"]
+    assert len(test_tasks) == 0

--- a/tests/e2e/test_e2e_loop.py
+++ b/tests/e2e/test_e2e_loop.py
@@ -1,5 +1,5 @@
 """
-E2E tests for crew run CLI — full code-review loop with stub agents.
+E2E tests for crew run CLI — full code-review loop with real subprocess stub agents.
 
 E-LO01: crew run → stub coder → stub reviewer approves → stub tester passes → done
 E-LO02: reviewer requests changes once → 2 implement cycles → approved + tested
@@ -7,11 +7,14 @@ E-LO03: crew run --max-iter 2, perpetual rejection → escalation gate after 2 i
 E-LO04: crew run --no-tester → no test task enqueued after approval
 """
 
+import os
+import pathlib
 import socket
+import subprocess
+import sys
 import threading
 import time
 
-import httpx
 import pytest
 import uvicorn
 from click.testing import CliRunner
@@ -22,6 +25,8 @@ from agent_crew.server import create_app
 
 pytestmark = pytest.mark.e2e
 
+_STUB_SCRIPT = str(pathlib.Path(__file__).parent / "stubs" / "stub_agent.py")
+
 
 def _find_free_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
@@ -31,7 +36,7 @@ def _find_free_port() -> int:
 
 @pytest.fixture
 def live_server(tmp_path):
-    """Start a real uvicorn server; yield (base_url, db_path); stop after test."""
+    """Start a real uvicorn server; yield (port, db_path); stop after test."""
     db_path = str(tmp_path / "tasks.db")
     port = _find_free_port()
     app = create_app(db_path)
@@ -42,43 +47,39 @@ def live_server(tmp_path):
     thread = threading.Thread(target=server.run, daemon=True)
     thread.start()
 
-    base_url = f"http://127.0.0.1:{port}"
+    # Wait for server ready
+    import httpx
     deadline = time.time() + 10.0
     while time.time() < deadline:
         try:
-            httpx.get(f"{base_url}/tasks", timeout=0.5)
+            httpx.get(f"http://127.0.0.1:{port}/tasks", timeout=0.5)
             break
         except Exception:
             time.sleep(0.05)
 
-    yield base_url, db_path
+    yield port, db_path
 
     server.should_exit = True
     thread.join(timeout=5.0)
 
 
-def _stub_agent(base_url: str, role: str, verdict: str | None = None, poll_timeout: float = 30.0):
-    """Poll for one task of `role`, submit a completed result, then return."""
-    task = None
-    deadline = time.time() + poll_timeout
-    while time.time() < deadline:
-        resp = httpx.get(f"{base_url}/tasks/next", params={"role": role}, timeout=2.0)
-        if resp.status_code == 200 and resp.json() is not None:
-            task = resp.json()
-            break
-        time.sleep(0.05)
-
-    if task is None:
-        raise TimeoutError(f"stub {role} found no task within {poll_timeout}s")
-
-    result = {
-        "task_id": task["task_id"],
-        "status": "completed",
-        "summary": f"stub {role} done",
-        "verdict": verdict,
-        "findings": [],
+def _stub(port: int, role: str, verdict: str | None = None, status: str = "completed", timeout: float = 30.0) -> subprocess.CompletedProcess:
+    """Run stub_agent.py as a subprocess and wait for it to finish."""
+    env = {
+        **os.environ,
+        "STUB_PORT": str(port),
+        "STUB_ROLE": role,
+        "STUB_STATUS": status,
+        "STUB_TIMEOUT": str(timeout),
     }
-    httpx.post(f"{base_url}/tasks/{task['task_id']}/result", json=result, timeout=2.0)
+    if verdict:
+        env["STUB_VERDICT"] = verdict
+    return subprocess.run(
+        [sys.executable, _STUB_SCRIPT],
+        env=env,
+        capture_output=True,
+        timeout=timeout + 5,
+    )
 
 
 def _start_cli(args: list[str]):
@@ -96,13 +97,13 @@ def _start_cli(args: list[str]):
 
 # E-LO01: basic happy path — coder done, reviewer approves, tester passes
 def test_e_lo01_basic_approve(live_server):
-    base_url, db_path = live_server
+    port, db_path = live_server
 
     cli_t, holder = _start_cli(["run", "feat X", "--db", db_path, "--branch", "main"])
 
-    _stub_agent(base_url, "coder")
-    _stub_agent(base_url, "reviewer", verdict="approve")
-    _stub_agent(base_url, "tester")
+    assert _stub(port, "coder").returncode == 0
+    assert _stub(port, "reviewer", verdict="approve").returncode == 0
+    assert _stub(port, "tester").returncode == 0
 
     cli_t.join(timeout=30.0)
     assert not cli_t.is_alive(), "CLI thread timed out"
@@ -114,17 +115,17 @@ def test_e_lo01_basic_approve(live_server):
 
 # E-LO02: reviewer requests changes once → 2 implement cycles → approved and tested
 def test_e_lo02_request_changes_then_approve(live_server):
-    base_url, db_path = live_server
+    port, db_path = live_server
 
     cli_t, holder = _start_cli(["run", "feat Y", "--db", db_path, "--branch", "main"])
 
     # iteration 1: coder done, reviewer rejects
-    _stub_agent(base_url, "coder")
-    _stub_agent(base_url, "reviewer", verdict="request_changes")
+    assert _stub(port, "coder").returncode == 0
+    assert _stub(port, "reviewer", verdict="request_changes").returncode == 0
     # iteration 2: coder done, reviewer approves, tester passes
-    _stub_agent(base_url, "coder")
-    _stub_agent(base_url, "reviewer", verdict="approve")
-    _stub_agent(base_url, "tester")
+    assert _stub(port, "coder").returncode == 0
+    assert _stub(port, "reviewer", verdict="approve").returncode == 0
+    assert _stub(port, "tester").returncode == 0
 
     cli_t.join(timeout=60.0)
     assert not cli_t.is_alive(), "CLI thread timed out"
@@ -136,18 +137,18 @@ def test_e_lo02_request_changes_then_approve(live_server):
 
 # E-LO03: --max-iter 2, perpetual rejection → escalation gate created
 def test_e_lo03_escalation_gate(live_server):
-    base_url, db_path = live_server
+    port, db_path = live_server
 
     cli_t, holder = _start_cli(
         ["run", "feat Z", "--db", db_path, "--branch", "main", "--max-iter", "2"]
     )
 
     # iteration 1: coder done, reviewer rejects
-    _stub_agent(base_url, "coder")
-    _stub_agent(base_url, "reviewer", verdict="request_changes")
+    assert _stub(port, "coder").returncode == 0
+    assert _stub(port, "reviewer", verdict="request_changes").returncode == 0
     # iteration 2: coder done, reviewer rejects again → escalate
-    _stub_agent(base_url, "coder")
-    _stub_agent(base_url, "reviewer", verdict="request_changes")
+    assert _stub(port, "coder").returncode == 0
+    assert _stub(port, "reviewer", verdict="request_changes").returncode == 0
 
     cli_t.join(timeout=60.0)
     assert not cli_t.is_alive(), "CLI thread timed out"
@@ -164,14 +165,14 @@ def test_e_lo03_escalation_gate(live_server):
 
 # E-LO04: --no-tester → no test task is enqueued after approval
 def test_e_lo04_no_tester(live_server):
-    base_url, db_path = live_server
+    port, db_path = live_server
 
     cli_t, holder = _start_cli(
         ["run", "feat W", "--db", db_path, "--branch", "main", "--no-tester"]
     )
 
-    _stub_agent(base_url, "coder")
-    _stub_agent(base_url, "reviewer", verdict="approve")
+    assert _stub(port, "coder").returncode == 0
+    assert _stub(port, "reviewer", verdict="approve").returncode == 0
 
     cli_t.join(timeout=30.0)
     assert not cli_t.is_alive(), "CLI thread timed out"


### PR DESCRIPTION
## Summary
- E-LO01~E-LO04: full E2E code-review loop workflow with stub agents
- Real server (uvicorn) + stub coder/reviewer/tester
- 4 tests passing, 130 total, ruff clean

## Test plan
- [ ] ruff check passes
- [ ] pytest 130 tests pass

🤖 Generated with Claude Code