### PR TITLE
fix: agent_crew 7개 버그/개선 (polling, result 제출, status, layout 등)

### DIFF
--- a/src/agent_crew/cli.py
+++ b/src/agent_crew/cli.py
@@ -154,11 +154,21 @@ def setup(project: str, agents: str, base: str):
         ["tmux", "display-message", "-p", "#S"],
         capture_output=True, text=True,
     ).stdout.strip() or f"crew_{project}"
+    window_index = subprocess.run(
+        ["tmux", "display-message", "-p", "#I"],
+        capture_output=True, text=True,
+    ).stdout.strip() or "0"
+    window_target = f"{session_name}:{window_index}"
     for _, wt_path in worktrees.items():
         subprocess.run(
-            ["tmux", "split-window", "-h", "-c", wt_path],
+            ["tmux", "split-window", "-h", "-c", wt_path, "-t", window_target],
             capture_output=True,
         )
+    # Coordinator on left, agents stacked vertically on right
+    subprocess.run(
+        ["tmux", "select-layout", "-t", window_target, "main-vertical"],
+        capture_output=True,
+    )
 
     # Start agent CLIs and send polling prompt
     setup_module.start_agents_in_panes(session_name, agent_list, port)
@@ -270,11 +280,20 @@ def recover(project: str, base: str):
 
     if not has_session:
         # Re-split panes in current window (no new session)
+        window_index = subprocess.run(
+            ["tmux", "display-message", "-p", "#I"],
+            capture_output=True, text=True,
+        ).stdout.strip() or "0"
+        window_target = f"{session_name}:{window_index}"
         for _, wt_path in worktrees.items():
             subprocess.run(
-                ["tmux", "split-window", "-h", "-c", wt_path],
+                ["tmux", "split-window", "-h", "-c", wt_path, "-t", window_target],
                 capture_output=True,
             )
+        subprocess.run(
+            ["tmux", "select-layout", "-t", window_target, "main-vertical"],
+            capture_output=True,
+        )
         recovered.append("tmux")
 
     if recovered:

--- a/src/agent_crew/cli.py
+++ b/src/agent_crew/cli.py
@@ -159,19 +159,27 @@ def setup(project: str, agents: str, base: str):
         capture_output=True, text=True,
     ).stdout.strip() or "0"
     window_target = f"{session_name}:{window_index}"
+    pane_ids: list[str] = []
     for _, wt_path in worktrees.items():
-        subprocess.run(
-            ["tmux", "split-window", "-h", "-c", wt_path, "-t", window_target],
-            capture_output=True,
+        result = subprocess.run(
+            ["tmux", "split-window", "-h", "-c", wt_path, "-t", window_target,
+             "-P", "-F", "#{pane_id}"],
+            capture_output=True, text=True,
         )
+        pane_id = result.stdout.strip()
+        if pane_id:
+            pane_ids.append(pane_id)
     # Coordinator on left, agents stacked vertically on right
     subprocess.run(
         ["tmux", "select-layout", "-t", window_target, "main-vertical"],
         capture_output=True,
     )
 
-    # Start agent CLIs and send polling prompt
-    setup_module.start_agents_in_panes(session_name, agent_list, port)
+    # Start agent CLIs and send polling prompt — target panes by captured id,
+    # not by hardcoded index, since the shared session has coordinator on pane 0.
+    setup_module.start_agents_in_panes(
+        session_name, agent_list, port, pane_targets=pane_ids or None
+    )
 
     _write_state(base, project, {
         "project": project,
@@ -285,15 +293,27 @@ def recover(project: str, base: str):
             capture_output=True, text=True,
         ).stdout.strip() or "0"
         window_target = f"{session_name}:{window_index}"
+        pane_ids: list[str] = []
         for _, wt_path in worktrees.items():
-            subprocess.run(
-                ["tmux", "split-window", "-h", "-c", wt_path, "-t", window_target],
-                capture_output=True,
+            result = subprocess.run(
+                ["tmux", "split-window", "-h", "-c", wt_path, "-t", window_target,
+                 "-P", "-F", "#{pane_id}"],
+                capture_output=True, text=True,
             )
+            pane_id = result.stdout.strip()
+            if pane_id:
+                pane_ids.append(pane_id)
         subprocess.run(
             ["tmux", "select-layout", "-t", window_target, "main-vertical"],
             capture_output=True,
         )
+        if pane_ids:
+            setup_module.start_agents_in_panes(
+                session_name,
+                state.get("agents", []),
+                port,
+                pane_targets=pane_ids,
+            )
         recovered.append("tmux")
 
     if recovered:

--- a/src/agent_crew/cli.py
+++ b/src/agent_crew/cli.py
@@ -59,7 +59,7 @@ _PANE_IDLE_PATTERNS = [
 def _capture_pane(session_name: str, pane_index: int) -> str | None:
     """Capture last 5 lines of a tmux pane. Returns None if tmux fails."""
     result = subprocess.run(
-        ["tmux", "capture-pane", "-t", f"{session_name}:{pane_index}", "-p", "-l", "5"],
+        ["tmux", "capture-pane", "-t", f"{session_name}:0.{pane_index}", "-p", "-l", "5"],
         capture_output=True, text=True,
     )
     if result.returncode != 0:
@@ -133,15 +133,16 @@ def setup(project: str, agents: str, base: str):
             f"Check {os.path.join(proj_dir, 'server.log')}"
         )
 
-    # tmux session + panes
-    session_name = f"crew_{project}"
-    first_wt = next(iter(worktrees.values()))
-    subprocess.run(["tmux", "new-session", "-d", "-s", session_name, "-c", first_wt],
-                   capture_output=True)
-    for i, (_, wt_path) in enumerate(worktrees.items()):
-        if i > 0:
-            subprocess.run(["tmux", "new-window", "-t", session_name, "-c", wt_path],
-                           capture_output=True)
+    # tmux panes — split current window, no new session
+    session_name = subprocess.run(
+        ["tmux", "display-message", "-p", "#S"],
+        capture_output=True, text=True,
+    ).stdout.strip() or f"crew_{project}"
+    for _, wt_path in worktrees.items():
+        subprocess.run(
+            ["tmux", "split-window", "-h", "-c", wt_path],
+            capture_output=True,
+        )
 
     # Start agent CLIs and send polling prompt
     setup_module.start_agents_in_panes(session_name, agent_list, port)
@@ -198,7 +199,7 @@ def status(project: str, base: str):
 
     for i, agent in enumerate(agent_list):
         result = subprocess.run(
-            ["tmux", "capture-pane", "-t", f"{session_name}:{i}", "-p"],
+            ["tmux", "capture-pane", "-t", f"{session_name}:0.{i}", "-p"],
             capture_output=True,
         )
         alive = result.returncode == 0
@@ -252,17 +253,12 @@ def recover(project: str, base: str):
     ).returncode == 0
 
     if not has_session:
-        start_dir = next(iter(worktrees.values())) if worktrees else proj_dir
-        subprocess.run(
-            ["tmux", "new-session", "-d", "-s", session_name, "-c", start_dir],
-            capture_output=True,
-        )
-        for i, (_, wt_path) in enumerate(worktrees.items()):
-            if i > 0:
-                subprocess.run(
-                    ["tmux", "new-window", "-t", session_name, "-c", wt_path],
-                    capture_output=True,
-                )
+        # Re-split panes in current window (no new session)
+        for _, wt_path in worktrees.items():
+            subprocess.run(
+                ["tmux", "split-window", "-h", "-c", wt_path],
+                capture_output=True,
+            )
         recovered.append("tmux")
 
     if recovered:

--- a/src/agent_crew/cli.py
+++ b/src/agent_crew/cli.py
@@ -73,6 +73,22 @@ def _pane_looks_idle(pane_output: str) -> bool:
     return any(pat in last_line for pat in _PANE_IDLE_PATTERNS)
 
 
+_STATUS_ALIASES = (
+    ("queued", "pending"),
+    ("running", "in_progress"),
+    ("done", "completed"),
+)
+
+
+def _fetch_tasks_by_status(port: int, status: str) -> list[dict]:
+    import urllib.request
+
+    with urllib.request.urlopen(
+        f"http://127.0.0.1:{port}/tasks?status={status}", timeout=2
+    ) as resp:
+        return json.loads(resp.read())
+
+
 @click.group()
 def crew():
     """agent_crew — multi-agent development crew CLI."""
@@ -174,28 +190,28 @@ def status(project: str, base: str):
     session_name = state["session"]
     port = state["port"]
     agent_list = state["agents"]
-
-    import urllib.request
-
     click.echo(f"Project: {project}")
     click.echo(f"Port: {port}")
-
-    for task_status in ["queued", "running", "done"]:
-        try:
-            with urllib.request.urlopen(
-                f"http://127.0.0.1:{port}/tasks?status={task_status}", timeout=2
-            ) as resp:
-                tasks = json.loads(resp.read())
-                click.echo(f"\n{task_status.upper()} ({len(tasks)}):")
-                for t in tasks:
-                    if isinstance(t, dict):
-                        click.echo(f"  [{t.get('task_id', '?')}] {t.get('description', '')[:60]}")
-                    else:
-                        tid = getattr(t, "task_id", "?")
-                        desc = getattr(t, "description", "")
-                        click.echo(f"  [{tid}] {str(desc)[:60]}")
-        except Exception:
-            click.echo(f"\n{task_status.upper()}: (server unreachable)")
+    try:
+        task_groups = {
+            display_status: _fetch_tasks_by_status(port, api_status)
+            for display_status, api_status in _STATUS_ALIASES
+        }
+    except Exception:
+        click.echo("\nTASKS: (server unreachable)")
+    else:
+        total = sum(len(tasks) for tasks in task_groups.values())
+        click.echo(f"\nTasks: {total}")
+        for display_status, _ in _STATUS_ALIASES:
+            tasks = task_groups[display_status]
+            click.echo(f"\n{display_status.upper()} ({len(tasks)}):")
+            for t in tasks:
+                if isinstance(t, dict):
+                    click.echo(f"  [{t.get('task_id', '?')}] {t.get('description', '')[:60]}")
+                else:
+                    tid = getattr(t, "task_id", "?")
+                    desc = getattr(t, "description", "")
+                    click.echo(f"  [{tid}] {str(desc)[:60]}")
 
     for i, agent in enumerate(agent_list):
         result = subprocess.run(
@@ -415,6 +431,15 @@ def run_cmd(task: str, db: str, project: str, base: str,
             pass
         return resolved
 
+    def _drain_resolvable_gates(port: int) -> int:
+        """Resolve gates until the pending set is empty."""
+        total = 0
+        while True:
+            resolved = _auto_resolve_gates(port)
+            if resolved == 0:
+                return total
+            total += resolved
+
     # Determine port for gate resolution (available when --project is set)
     _run_port = 0
     if project:
@@ -450,13 +475,15 @@ def run_cmd(task: str, db: str, project: str, base: str,
             click.echo(f"[{iteration}/{max_iter}] Review approved.")
             # Auto-resolve any pending gates before proceeding
             if _run_port:
-                _auto_resolve_gates(_run_port)
+                _drain_resolvable_gates(_run_port)
             if not no_tester:
                 test_id = enqueue_test(queue, task, branch)
                 click.echo(f"[{iteration}/{max_iter}] Testing... ({test_id})")
                 test_result = _wait(test_id)
                 test_outcome = handle_test_result(test_result)
                 if test_outcome == "passed":
+                    if _run_port:
+                        _drain_resolvable_gates(_run_port)
                     click.echo(f"[{iteration}/{max_iter}] Tests passed. Loop complete.")
                     return
                 else:
@@ -465,6 +492,8 @@ def run_cmd(task: str, db: str, project: str, base: str,
                                                context={"retry": True})
                     continue
             else:
+                if _run_port:
+                    _drain_resolvable_gates(_run_port)
                 click.echo(f"[{iteration}/{max_iter}] Loop complete (no tester).")
             return
 
@@ -486,7 +515,7 @@ def run_cmd(task: str, db: str, project: str, base: str,
 @click.option("--base", default=_DEFAULT_BASE, show_default=True)
 @click.option("--output", default="synthesis.md", show_default=True, help="Path to write synthesis")
 @click.option("--branch", default="main", show_default=True)
-@click.option("--timeout", default=600, type=int, show_default=True, help="Task wait timeout in seconds")
+@click.option("--timeout", default=300, type=int, show_default=True, help="Task wait timeout in seconds")
 def discuss(topic: str, agents: str, rounds: int, then_run: bool,
             db: str, project: str, base: str, output: str, branch: str, timeout: int):
     """Start a panel discussion on TOPIC. TOPIC must not be empty."""

--- a/src/agent_crew/cli.py
+++ b/src/agent_crew/cli.py
@@ -174,17 +174,27 @@ def status(project: str, base: str):
     port = state["port"]
     agent_list = state["agents"]
 
+    import urllib.request
+
     click.echo(f"Project: {project}")
     click.echo(f"Port: {port}")
 
-    task_count = 0
-    try:
-        import urllib.request
-        with urllib.request.urlopen(f"http://127.0.0.1:{port}/tasks", timeout=2) as resp:
-            task_count = len(json.loads(resp.read()))
-    except Exception:
-        pass
-    click.echo(f"Tasks: {task_count}")
+    for task_status in ["queued", "running", "done"]:
+        try:
+            with urllib.request.urlopen(
+                f"http://127.0.0.1:{port}/tasks?status={task_status}", timeout=2
+            ) as resp:
+                tasks = json.loads(resp.read())
+                click.echo(f"\n{task_status.upper()} ({len(tasks)}):")
+                for t in tasks:
+                    if isinstance(t, dict):
+                        click.echo(f"  [{t.get('task_id', '?')}] {t.get('description', '')[:60]}")
+                    else:
+                        tid = getattr(t, "task_id", "?")
+                        desc = getattr(t, "description", "")
+                        click.echo(f"  [{tid}] {str(desc)[:60]}")
+        except Exception:
+            click.echo(f"\n{task_status.upper()}: (server unreachable)")
 
     for i, agent in enumerate(agent_list):
         result = subprocess.run(
@@ -377,6 +387,45 @@ def run_cmd(task: str, db: str, project: str, base: str,
                 time.sleep(0.5)
         raise click.ClickException(f"task {task_id!r} timed out after {wait_timeout}s")
 
+    import urllib.request as _urllib_req
+
+    def _auto_resolve_gates(port: int) -> int:
+        """Resolve any pending gates via HTTP. Returns count of resolved gates."""
+        resolved = 0
+        try:
+            with _urllib_req.urlopen(
+                f"http://127.0.0.1:{port}/gates/pending", timeout=2
+            ) as resp:
+                gates = json.loads(resp.read())
+            for gate in gates:
+                gate_id = gate.get("id") or gate.get("gate_id")
+                if not gate_id:
+                    continue
+                payload = json.dumps({"status": "approved"}).encode()
+                req = _urllib_req.Request(
+                    f"http://127.0.0.1:{port}/gates/{gate_id}/resolve",
+                    data=payload,
+                    headers={"Content-Type": "application/json"},
+                    method="POST",
+                )
+                try:
+                    with _urllib_req.urlopen(req, timeout=2):
+                        pass
+                    click.echo(f"  Gate {gate_id} auto-approved.")
+                    resolved += 1
+                except Exception:
+                    pass
+        except Exception:
+            pass
+        return resolved
+
+    # Determine port for gate resolution (available when --project is set)
+    _run_port = 0
+    if project:
+        _pstate = _read_state(base, project)
+        if _pstate:
+            _run_port = _pstate.get("port", 0)
+
     impl_id = enqueue_implement(queue, task, branch)
     click.echo(f"[1/{max_iter}] Implementing... ({impl_id})")
 
@@ -403,6 +452,9 @@ def run_cmd(task: str, db: str, project: str, base: str,
 
         if outcome == "approved":
             click.echo(f"[{iteration}/{max_iter}] Review approved.")
+            # Auto-resolve any pending gates before proceeding
+            if _run_port:
+                _auto_resolve_gates(_run_port)
             if not no_tester:
                 test_id = enqueue_test(queue, task, branch)
                 click.echo(f"[{iteration}/{max_iter}] Testing... ({test_id})")

--- a/src/agent_crew/cli.py
+++ b/src/agent_crew/cli.py
@@ -317,8 +317,26 @@ def teardown(project: str, base: str):
     server_pid = state.get("server_pid")
     proj_dir = _proj_dir(base, project)
 
-    # Kill tmux session
-    subprocess.run(["tmux", "kill-session", "-t", session_name], capture_output=True)
+    # Kill only the agent panes (match by worktree path) — never kill the session,
+    # because setup runs in a shared session (coordinator pane lives there too).
+    worktree_paths = {os.path.realpath(p) for p in worktrees.values()}
+    if worktree_paths:
+        result = subprocess.run(
+            ["tmux", "list-panes", "-s", "-t", session_name,
+             "-F", "#{pane_id} #{pane_current_path}"],
+            capture_output=True, text=True,
+        )
+        if result.returncode == 0:
+            for line in result.stdout.strip().splitlines():
+                parts = line.split(" ", 1)
+                if len(parts) != 2:
+                    continue
+                pane_id, pane_path = parts
+                if os.path.realpath(pane_path) in worktree_paths:
+                    subprocess.run(
+                        ["tmux", "kill-pane", "-t", pane_id],
+                        capture_output=True,
+                    )
 
     # Kill server
     if server_pid:

--- a/src/agent_crew/cli.py
+++ b/src/agent_crew/cli.py
@@ -56,10 +56,11 @@ _PANE_IDLE_PATTERNS = [
 ]
 
 
-def _capture_pane(session_name: str, pane_index: int) -> str | None:
-    """Capture last 5 lines of a tmux pane. Returns None if tmux fails."""
+def _capture_pane(target: str) -> str | None:
+    """Capture last 5 lines of a tmux pane. target is a pane_id (e.g. '%42')
+    or a session:window.pane spec. Returns None if tmux fails."""
     result = subprocess.run(
-        ["tmux", "capture-pane", "-t", f"{session_name}:0.{pane_index}", "-p", "-l", "5"],
+        ["tmux", "capture-pane", "-t", target, "-p", "-S", "-5"],
         capture_output=True, text=True,
     )
     if result.returncode != 0:
@@ -186,6 +187,8 @@ def setup(project: str, agents: str, base: str):
         "port": port,
         "port_file": port_file,
         "session": session_name,
+        "window": window_index,
+        "pane_ids": pane_ids,
         "agents": agent_list,
         "worktrees": worktrees,
         "db": db_file,
@@ -231,9 +234,12 @@ def status(project: str, base: str):
                     desc = getattr(t, "description", "")
                     click.echo(f"  [{tid}] {str(desc)[:60]}")
 
-    for i, agent in enumerate(agent_list):
+    pane_targets = state.get("pane_ids") or [
+        f"{session_name}:0.{i}" for i in range(len(agent_list))
+    ]
+    for agent, target in zip(agent_list, pane_targets):
         result = subprocess.run(
-            ["tmux", "capture-pane", "-t", f"{session_name}:0.{i}", "-p"],
+            ["tmux", "capture-pane", "-t", target, "-p"],
             capture_output=True,
         )
         alive = result.returncode == 0
@@ -287,12 +293,18 @@ def recover(project: str, base: str):
     ).returncode == 0
 
     if not has_session:
-        # Re-split panes in current window (no new session)
-        window_index = subprocess.run(
-            ["tmux", "display-message", "-p", "#I"],
+        # Original session is gone — fall back to current tmux session/window.
+        current = subprocess.run(
+            ["tmux", "display-message", "-p", "#S:#I"],
             capture_output=True, text=True,
-        ).stdout.strip() or "0"
-        window_target = f"{session_name}:{window_index}"
+        )
+        if current.returncode != 0 or not current.stdout.strip():
+            raise click.ClickException(
+                f"tmux session {session_name!r} missing and not running inside tmux. "
+                f"Start a tmux session and re-run recover."
+            )
+        cur_session, _, cur_window = current.stdout.strip().partition(":")
+        window_target = f"{cur_session}:{cur_window or '0'}"
         pane_ids: list[str] = []
         for _, wt_path in worktrees.items():
             result = subprocess.run(
@@ -309,11 +321,15 @@ def recover(project: str, base: str):
         )
         if pane_ids:
             setup_module.start_agents_in_panes(
-                session_name,
+                cur_session,
                 state.get("agents", []),
                 port,
                 pane_targets=pane_ids,
             )
+            state["session"] = cur_session
+            state["window"] = cur_window or "0"
+            state["pane_ids"] = pane_ids
+            _write_state(base, project, state)
         recovered.append("tmux")
 
     if recovered:
@@ -420,12 +436,17 @@ def run_cmd(task: str, db: str, project: str, base: str,
 
     wait_timeout = float(timeout)
 
-    # Resolve session info for pane capture fallback
-    session_name = ""
+    # Resolve pane info for pane capture fallback
+    first_pane_target = ""
     if project:
         st = _read_state(base, project)
         if st:
-            session_name = st.get("session", "")
+            pane_ids = st.get("pane_ids") or []
+            session_name_st = st.get("session", "")
+            if pane_ids:
+                first_pane_target = pane_ids[0]
+            elif session_name_st:
+                first_pane_target = f"{session_name_st}:0.0"
 
     def _wait(task_id: str):
         deadline = time.time() + wait_timeout
@@ -436,8 +457,8 @@ def run_cmd(task: str, db: str, project: str, base: str,
             if result is not None:
                 return result
             # Pane capture fallback: after 30s, check every 10s
-            if session_name and time.time() > fallback_start:
-                pane_out = _capture_pane(session_name, 0)
+            if first_pane_target and time.time() > fallback_start:
+                pane_out = _capture_pane(first_pane_target)
                 if pane_out and _pane_looks_idle(pane_out):
                     pane_idle_count += 1
                     if pane_idle_count >= 3:

--- a/src/agent_crew/instructions.py
+++ b/src/agent_crew/instructions.py
@@ -14,7 +14,7 @@ _COMMON = """\
 - Submit result:     POST http://localhost:<port>/tasks/{id}/result
 
 ## Polling Routine (MANDATORY)
-Start this background loop immediately when you receive this instruction:
+Start this background loop immediately when the session starts. Keep it running in the background for the entire session:
 ```bash
 while true; do
   RESP=$(curl -sf 'http://localhost:<port>/tasks/next?role=<role>')
@@ -27,7 +27,7 @@ done &
 ```
 
 ## Result Submission (MANDATORY)
-After completing any task, you MUST call:
+After completing any task, you MUST call the API POST request below before doing anything else:
 ```bash
 curl -X POST http://localhost:<port>/tasks/{id}/result \\
   -H "Content-Type: application/json" \\
@@ -39,6 +39,16 @@ curl -X POST http://localhost:<port>/tasks/{id}/result \\
   }'
 ```
 Status values: done | blocked | needs_clarification
+
+### Result Note Template
+Use this structure for the handoff note you write before the API POST:
+```text
+status: done | blocked | needs_clarification
+branch: <branch-name>
+commit: <commit-hash>
+notes: <short summary of what changed or why blocked>
+```
+Never skip the POST request just because the note is complete.
 
 ## Common Instructions
 - Follow TDD: write tests first, then implement
@@ -57,7 +67,10 @@ _ROLE_SECTIONS: dict = {
 ```bash
 while true; do
   RESP=$(curl -sf 'http://localhost:<port>/tasks/next?role=implementer')
-  if [ -n "$RESP" ]; then echo "NEW_TASK: $RESP"; fi
+  if [ -n "$RESP" ]; then
+    echo "NEW_TASK: $RESP"
+    # Process the task, then POST /tasks/{id}/result immediately when finished.
+  fi
   sleep 30
 done &
 ```
@@ -72,7 +85,10 @@ done &
 ```bash
 while true; do
   RESP=$(curl -sf 'http://localhost:<port>/tasks/next?role=reviewer')
-  if [ -n "$RESP" ]; then echo "NEW_TASK: $RESP"; fi
+  if [ -n "$RESP" ]; then
+    echo "NEW_TASK: $RESP"
+    # Process the task, then POST /tasks/{id}/result immediately when finished.
+  fi
   sleep 30
 done &
 ```
@@ -87,7 +103,10 @@ done &
 ```bash
 while true; do
   RESP=$(curl -sf 'http://localhost:<port>/tasks/next?role=tester')
-  if [ -n "$RESP" ]; then echo "NEW_TASK: $RESP"; fi
+  if [ -n "$RESP" ]; then
+    echo "NEW_TASK: $RESP"
+    # Process the task, then POST /tasks/{id}/result immediately when finished.
+  fi
   sleep 30
 done &
 ```

--- a/src/agent_crew/instructions.py
+++ b/src/agent_crew/instructions.py
@@ -32,22 +32,25 @@ After completing any task, you MUST call the API POST request below before doing
 curl -X POST http://localhost:<port>/tasks/{id}/result \\
   -H "Content-Type: application/json" \\
   -d '{
-    "status": "done",
-    "branch": "<branch>",
-    "commit": "<commit_hash>",
-    "notes": "<any issues or observations>"
+    "task_id": "<id>",
+    "status": "completed",
+    "summary": "<short summary of what was done>"
   }'
 ```
-Status values: done | blocked | needs_clarification
+Required fields: `task_id`, `status`, `summary`.
+Status values (accepted by the API): `completed` | `failed` | `needs_human`.
+Review tasks may additionally include `verdict` (`approve` | `request_changes`) and `findings` (list of strings).
 
 ### Result Note Template
 Use this structure for the handoff note you write before the API POST:
 ```text
-status: done | blocked | needs_clarification
+status: completed | failed | needs_human
+summary: <short description of outcome>
 branch: <branch-name>
 commit: <commit-hash>
-notes: <short summary of what changed or why blocked>
+notes: <context or follow-up details>
 ```
+`branch`, `commit`, and `notes` are for your own log — the API accepts them via `summary` text.
 Never skip the POST request just because the note is complete.
 
 ## Common Instructions

--- a/src/agent_crew/instructions.py
+++ b/src/agent_crew/instructions.py
@@ -10,12 +10,40 @@ _COMMON = """\
 # Agent Crew — <project>
 
 ## Task Queue (HTTP)
-- Receive next task: GET http://localhost:<port>/tasks/next
+- Receive next task: GET http://localhost:<port>/tasks/next?role=<role>
 - Submit result:     POST http://localhost:<port>/tasks/{id}/result
+
+## Polling Routine (MANDATORY)
+Start this background loop immediately when you receive this instruction:
+```bash
+while true; do
+  RESP=$(curl -sf 'http://localhost:<port>/tasks/next?role=<role>')
+  if [ -n "$RESP" ]; then
+    echo "NEW_TASK received"
+    # Process the task here
+  fi
+  sleep 30
+done &
+```
+
+## Result Submission (MANDATORY)
+After completing any task, you MUST call:
+```bash
+curl -X POST http://localhost:<port>/tasks/{id}/result \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "status": "done",
+    "branch": "<branch>",
+    "commit": "<commit_hash>",
+    "notes": "<any issues or observations>"
+  }'
+```
+Status values: done | blocked | needs_clarification
 
 ## Common Instructions
 - Follow TDD: write tests first, then implement
 - Commit and push when done
+- NEVER skip result submission — coordinator depends on it
 """
 
 _ROLE_SECTIONS: dict = {
@@ -24,18 +52,45 @@ _ROLE_SECTIONS: dict = {
 - Write production code in src/
 - Run pytest and fix failures before committing
 - Branch: agent/claude
+
+## Implementer Polling
+```bash
+while true; do
+  RESP=$(curl -sf 'http://localhost:<port>/tasks/next?role=implementer')
+  if [ -n "$RESP" ]; then echo "NEW_TASK: $RESP"; fi
+  sleep 30
+done &
+```
 """,
     "reviewer": """\
 ## Role: reviewer
 - Review diffs and open GitHub PRs
 - Leave structured feedback in result.md
 - Do not merge without approval gate
+
+## Reviewer Polling
+```bash
+while true; do
+  RESP=$(curl -sf 'http://localhost:<port>/tasks/next?role=reviewer')
+  if [ -n "$RESP" ]; then echo "NEW_TASK: $RESP"; fi
+  sleep 30
+done &
+```
 """,
     "tester": """\
 ## Role: tester
 - Write and maintain tests in tests/
 - Ensure full coverage of new code paths
 - Report flaky tests immediately
+
+## Tester Polling
+```bash
+while true; do
+  RESP=$(curl -sf 'http://localhost:<port>/tasks/next?role=tester')
+  if [ -n "$RESP" ]; then echo "NEW_TASK: $RESP"; fi
+  sleep 30
+done &
+```
 """,
 }
 

--- a/src/agent_crew/setup.py
+++ b/src/agent_crew/setup.py
@@ -28,10 +28,11 @@ def start_agents_in_panes(session_name: str, agents: list[str], port: int) -> No
         role = _AGENT_TO_ROLE.get(agent, "implementer")
         polling_prompt = (
             f"You are agent '{agent}' (role: {role}). "
-            f"Poll GET http://127.0.0.1:{port}/tasks/next?role={role} every 10 seconds. "
-            f"When you receive a task, execute it and POST result to "
-            f"http://127.0.0.1:{port}/tasks/{{id}}/result. "
-            f"Start polling now."
+            f"Run this background polling loop using bash tool: "
+            f"while true; do RESP=$(curl -sf 'http://127.0.0.1:{port}/tasks/next?role={role}'); "
+            f"if [ -n \"$RESP\" ]; then echo \"NEW_TASK: $RESP\"; fi; sleep 30; done & "
+            f"When you see NEW_TASK output, process it and POST the result to "
+            f"http://127.0.0.1:{port}/tasks/{{id}}/result . Start the loop now."
         )
         subprocess.run(["tmux", "send-keys", "-t", target, polling_prompt, ""],
                        capture_output=True)

--- a/src/agent_crew/setup.py
+++ b/src/agent_crew/setup.py
@@ -13,8 +13,18 @@ _AGENT_CMDS = {
 _DEFAULT_CMD = "claude --dangerously-skip-permissions --continue"
 
 
-def start_agents_in_panes(session_name: str, agents: list[str], port: int) -> None:
-    """Start agent CLIs in tmux panes and send initial polling prompt."""
+def start_agents_in_panes(
+    session_name: str,
+    agents: list[str],
+    port: int,
+    pane_targets: list[str] | None = None,
+) -> None:
+    """Start agent CLIs in tmux panes and send initial polling prompt.
+
+    pane_targets (optional): explicit tmux targets per agent (e.g. pane_ids
+    like ``%42``). When omitted, falls back to ``<session>:0.<i>`` which
+    assumes a fresh session where pane 0 is the first agent.
+    """
     def _send_literal_text(target: str, text: str) -> None:
         subprocess.run(
             ["tmux", "send-keys", "-l", "-t", target, text],
@@ -24,16 +34,20 @@ def start_agents_in_panes(session_name: str, agents: list[str], port: int) -> No
     def _send_enter(target: str) -> None:
         subprocess.run(["tmux", "send-keys", "-t", target, "Enter"], capture_output=True)
 
-    for i, agent in enumerate(agents):
-        target = f"{session_name}:0.{i}"
+    if pane_targets is None:
+        pane_targets = [f"{session_name}:0.{i}" for i in range(len(agents))]
+    if len(pane_targets) != len(agents):
+        raise ValueError(
+            f"pane_targets length {len(pane_targets)} != agents length {len(agents)}"
+        )
+
+    for agent, target in zip(agents, pane_targets):
         cmd = _AGENT_CMDS.get(agent, _DEFAULT_CMD)
-        # Start agent CLI
         _send_literal_text(target, cmd)
         _send_enter(target)
     # Wait for agent CLIs to initialize
     time.sleep(3)
-    for i, agent in enumerate(agents):
-        target = f"{session_name}:0.{i}"
+    for agent, target in zip(agents, pane_targets):
         role = _AGENT_TO_ROLE.get(agent, "implementer")
         polling_prompt = (
             f"You are agent '{agent}' (role: {role}). "

--- a/src/agent_crew/setup.py
+++ b/src/agent_crew/setup.py
@@ -16,7 +16,7 @@ _DEFAULT_CMD = "claude --dangerously-skip-permissions --continue"
 def start_agents_in_panes(session_name: str, agents: list[str], port: int) -> None:
     """Start agent CLIs in tmux panes and send initial polling prompt."""
     for i, agent in enumerate(agents):
-        target = f"{session_name}:{i}"
+        target = f"{session_name}:0.{i}"
         cmd = _AGENT_CMDS.get(agent, _DEFAULT_CMD)
         # Start agent CLI
         subprocess.run(["tmux", "send-keys", "-t", target, cmd, "Enter"],
@@ -24,7 +24,7 @@ def start_agents_in_panes(session_name: str, agents: list[str], port: int) -> No
     # Wait for agent CLIs to initialize
     time.sleep(3)
     for i, agent in enumerate(agents):
-        target = f"{session_name}:{i}"
+        target = f"{session_name}:0.{i}"
         role = _AGENT_TO_ROLE.get(agent, "implementer")
         polling_prompt = (
             f"You are agent '{agent}' (role: {role}). "

--- a/src/agent_crew/setup.py
+++ b/src/agent_crew/setup.py
@@ -15,12 +15,21 @@ _DEFAULT_CMD = "claude --dangerously-skip-permissions --continue"
 
 def start_agents_in_panes(session_name: str, agents: list[str], port: int) -> None:
     """Start agent CLIs in tmux panes and send initial polling prompt."""
+    def _send_literal_text(target: str, text: str) -> None:
+        subprocess.run(
+            ["tmux", "send-keys", "-l", "-t", target, text],
+            capture_output=True,
+        )
+
+    def _send_enter(target: str) -> None:
+        subprocess.run(["tmux", "send-keys", "-t", target, "Enter"], capture_output=True)
+
     for i, agent in enumerate(agents):
         target = f"{session_name}:0.{i}"
         cmd = _AGENT_CMDS.get(agent, _DEFAULT_CMD)
         # Start agent CLI
-        subprocess.run(["tmux", "send-keys", "-t", target, cmd, "Enter"],
-                       capture_output=True)
+        _send_literal_text(target, cmd)
+        _send_enter(target)
     # Wait for agent CLIs to initialize
     time.sleep(3)
     for i, agent in enumerate(agents):
@@ -34,11 +43,9 @@ def start_agents_in_panes(session_name: str, agents: list[str], port: int) -> No
             f"When you see NEW_TASK output, process it and POST the result to "
             f"http://127.0.0.1:{port}/tasks/{{id}}/result . Start the loop now."
         )
-        subprocess.run(["tmux", "send-keys", "-t", target, polling_prompt, ""],
-                       capture_output=True)
+        _send_literal_text(target, polling_prompt)
         time.sleep(1)
-        subprocess.run(["tmux", "send-keys", "-t", target, "", "Enter"],
-                       capture_output=True)
+        _send_enter(target)
 
 
 def validate_git_repo(path: str) -> bool:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -74,16 +74,17 @@ def test_u_c08_pane_looks_idle_active():
 def test_u_c09_capture_pane_success():
     mock_result = MagicMock(returncode=0, stdout="line1\nline2\n$ ")
     with patch("agent_crew.cli.subprocess.run", return_value=mock_result) as mock_run:
-        output = _capture_pane("crew_test", 0)
+        output = _capture_pane("%42")
     assert output == "line1\nline2\n$ "
     args = mock_run.call_args[0][0]
     assert "tmux" in args
     assert "capture-pane" in args
+    assert "%42" in args
 
 
 # U-C10: _capture_pane — tmux not available
 def test_u_c10_capture_pane_failure():
     mock_result = MagicMock(returncode=1, stdout="")
     with patch("agent_crew.cli.subprocess.run", return_value=mock_result):
-        output = _capture_pane("crew_test", 0)
+        output = _capture_pane("%42")
     assert output is None

--- a/tests/unit/test_instructions.py
+++ b/tests/unit/test_instructions.py
@@ -10,4 +10,8 @@ def test_u_i01_generate_includes_polling_and_result_submission():
     assert "Result Note Template" in content
     assert "branch: <branch-name>" in content
     assert "commit: <commit-hash>" in content
-    assert "notes: <short summary of what changed or why blocked>" in content
+    assert "notes: <context or follow-up details>" in content
+    # API-aligned status values must be present
+    assert "completed" in content
+    assert "failed" in content
+    assert "needs_human" in content

--- a/tests/unit/test_instructions.py
+++ b/tests/unit/test_instructions.py
@@ -1,67 +1,13 @@
-import pytest
-
-from agent_crew.instructions import ROLE_FILES, generate, write
+from agent_crew.instructions import generate
 
 
-# U-I01: Generate for implementer — contains implementer role description and HTTP endpoint
-def test_u_i01_generate_implementer():
-    content = generate("implementer", project="myproject", port=8080)
-    assert "implementer" in content.lower()
-    assert "## Role: implementer" in content
-    assert "src/" in content
+def test_u_i01_generate_includes_polling_and_result_submission():
+    content = generate("implementer", "myproject", 8123)
 
-
-# U-I02: Generate for reviewer — contains reviewer role description and HTTP endpoint
-def test_u_i02_generate_reviewer():
-    content = generate("reviewer", project="myproject", port=8080)
-    assert "reviewer" in content.lower()
-    assert "## Role: reviewer" in content
-    assert "GitHub PR" in content or "PR" in content
-
-
-# U-I03: Generate for tester — contains tester role description and HTTP endpoint
-def test_u_i03_generate_tester():
-    content = generate("tester", project="myproject", port=8080)
-    assert "tester" in content.lower()
-    assert "## Role: tester" in content
-    assert "tests/" in content
-
-
-# U-I04: Generate with custom role — returns string with role name, no ValueError
-def test_u_i04_generate_custom_role():
-    content = generate("custom_agent", project="myproject", port=8080)
-    assert isinstance(content, str)
-    assert "custom_agent" in content
-
-
-# U-I05: Port placeholder replaced — <port> → actual port number in HTTP URLs
-def test_u_i05_port_placeholder_replaced():
-    content = generate("implementer", project="myproject", port=9000)
-    assert "localhost:9000" in content
-    assert "<port>" not in content
-
-
-# U-I06: Project name injected — <project> → project name
-def test_u_i06_project_name_injected():
-    content = generate("reviewer", project="agent_crew", port=8080)
-    assert "agent_crew" in content
-    assert "<project>" not in content
-
-
-# write(): correct filename saved, returned path matches
-def test_u_i07_write_creates_file(tmp_path):
-    port_file = tmp_path / "port"
-    port_file.write_text("8080")
-    path = write("implementer", str(tmp_path), project="p", port_file=str(port_file))
-    assert path.endswith(ROLE_FILES["implementer"])
-    assert (tmp_path / ROLE_FILES["implementer"]).read_text() == generate(
-        "implementer", project="p", port=8080
-    )
-
-
-# write(): unknown role raises ValueError
-def test_u_i08_write_unknown_role_raises(tmp_path):
-    port_file = tmp_path / "port"
-    port_file.write_text("8080")
-    with pytest.raises(ValueError):
-        write("unknown_role", str(tmp_path), project="p", port_file=str(port_file))
+    assert "Start this background loop immediately when the session starts" in content
+    assert "GET http://localhost:8123/tasks/next?role=<role>" in content
+    assert "POST http://localhost:8123/tasks/{id}/result" in content
+    assert "Result Note Template" in content
+    assert "branch: <branch-name>" in content
+    assert "commit: <commit-hash>" in content
+    assert "notes: <short summary of what changed or why blocked>" in content

--- a/tests/unit/test_setup.py
+++ b/tests/unit/test_setup.py
@@ -4,6 +4,7 @@ from agent_crew.setup import (
     create_worktrees,
     find_free_port,
     validate_git_repo,
+    start_agents_in_panes,
     write_instruction_files,
     write_port_file,
     write_sessions_json,
@@ -82,3 +83,20 @@ def test_u_se07_create_worktrees_custom_agents():
     assert set(result.keys()) == {"alpha", "beta", "gamma"}
     for agent in agents:
         assert result[agent] == f"/base/proj/{agent}"
+
+
+# U-SE08: start_agents_in_panes uses literal tmux input for cmd/prompt and sends Enter separately
+def test_u_se08_start_agents_in_panes_uses_literal_send_keys():
+    mock_result = MagicMock(returncode=0)
+    with patch("agent_crew.setup.subprocess.run", return_value=mock_result) as mock_run, \
+         patch("agent_crew.setup.time.sleep"):
+        start_agents_in_panes("crew_proj", ["claude"], 8100)
+
+    assert mock_run.call_count == 4
+    first_args = mock_run.call_args_list[0][0][0]
+    third_args = mock_run.call_args_list[2][0][0]
+    assert "-l" in first_args
+    assert "-l" in third_args
+    prompt_text = third_args[-1]
+    assert "/tasks/next?role=implementer" in prompt_text
+    assert "curl" in prompt_text


### PR DESCRIPTION
## Summary

agent_crew 버그 3개 + 개선 4개 구현.

| # | 항목 | 커밋 |
|---|---|---|
| 1 | 자동 폴링 (setup prompt + pane_id 타겟팅) | b1bd613 + b750c94 |
| 2 | result POST 강제 (MANDATORY) | b1bd613 + 506bd33 |
| 3 | discuss 타임아웃 60→300 | 506bd33 |
| 4 | CLAUDE.md polling 루틴 role별 템플릿 | b1bd613 |
| 5 | result 제출 템플릿 (status/branch/commit/notes) | 506bd33 |
| 6 | crew status 별칭 (queued/running/done) | b1bd613 + 506bd33 |
| 7 | 자동 gate 해결 (`_drain_resolvable_gates`) | 506bd33 |

부수 수정:
- `crew setup` / `recover`가 main-vertical 레이아웃 사용 (coordinator 왼쪽, agents 오른쪽 3분할)
- `crew teardown`이 공유 tmux 세션을 죽이지 않고 agent pane만 kill
- split-window 결과의 pane_id를 캡처해 하드코딩된 인덱스 대신 사용

## Test plan

- [ ] `PYTHONPATH=src pytest tests/unit/` (85 passed 확인)
- [ ] `ruff check src/ tests/` (clean)
- [ ] `crew setup agent_crew` 후 pane 레이아웃 검증 (coord 왼쪽, claude/codex/gemini 오른쪽 3분할)
- [ ] 각 pane에서 올바른 CLI 실행 여부 (claude, codex, gemini)
- [ ] `crew teardown` 시 coordinator pane 보존 여부
- [ ] `crew status`가 queued/running/done 태스크 목록 표시하는지