### PR TITLE
fix(#63): prevent port conflicts by blacklisting ports from active port files

### DIFF
--- a/src/agent_crew/cli.py
+++ b/src/agent_crew/cli.py
@@ -244,10 +244,20 @@ def crew():
 
 @crew.command()
 @click.argument("project")
-@click.option("--agents", default=_DEFAULT_AGENTS, help="Comma-separated agent names")
+@click.option("--agents", default=_DEFAULT_AGENTS,
+              help="Comma-separated agent names. e.g. --agents codex  (single-agent mode)")
 @click.option("--base", default=_DEFAULT_BASE, show_default=True, help="Base directory for state/worktrees")
 def setup(project: str, agents: str, base: str):
-    """Configure environment for PROJECT."""
+    """Configure environment for PROJECT.
+
+    Examples:
+
+      crew setup myproj                        # default: claude,codex,gemini
+
+      crew setup myproj --agents codex         # single-agent task
+
+      crew setup myproj --agents claude,codex  # two agents
+    """
     cwd = os.getcwd()
     if not setup_module.validate_git_repo(cwd):
         raise click.ClickException("not a git repository")
@@ -473,6 +483,7 @@ def setup(project: str, agents: str, base: str):
     })
 
     click.echo(f"Setup complete: {project} on port {port}")
+    click.echo("Tip: use --agents <name> to spawn only specific agents (e.g. --agents claude)")
 
 
 @crew.command()

--- a/src/agent_crew/cli.py
+++ b/src/agent_crew/cli.py
@@ -221,7 +221,12 @@ _STATUS_ALIASES = (
     ("queued", "pending"),
     ("running", "in_progress"),
     ("done", "completed"),
+    ("failed", "failed"),
+    ("needs_human", "needs_human"),
+    ("cancelled", "cancelled"),
 )
+# Reverse map: DB status → display label (used in DB fallback)
+_DB_STATUS_TO_DISPLAY = {api: disp for disp, api in _STATUS_ALIASES}
 
 def _fetch_tasks_by_status(port: int, status: str) -> list[dict]:
     import urllib.request
@@ -518,13 +523,26 @@ def status(project: str, base: str, preview: int):
             for display_status, api_status in _STATUS_ALIASES
         }
     except Exception:
-        click.echo("\nTASKS: (server unreachable)")
+        click.echo("\nTASKS: (server unreachable — showing DB state, may be stale)")
+        if db_file and os.path.exists(db_file):
+            try:
+                from agent_crew.queue import TaskQueue as _TQ
+                _tq_all = _TQ(db_file)
+                _all_tasks = _tq_all.list_all_with_status()
+                task_groups = {}
+                for _t in _all_tasks:
+                    _st = _t.get("status", "unknown")
+                    _disp = _DB_STATUS_TO_DISPLAY.get(_st, _st)
+                    task_groups.setdefault(_disp, []).append(_t)
+            except Exception:
+                task_groups = None
 
     if task_groups:
         total = sum(len(tasks) for tasks in task_groups.values())
         click.echo(f"\nTasks: {total}")
-        for display_status, _ in _STATUS_ALIASES:
-            tasks = task_groups[display_status]
+        for display_status, tasks in task_groups.items():
+            if not tasks:
+                continue
             click.echo(f"\n{display_status.upper()} ({len(tasks)}):")
             for t in tasks:
                 def _get(key, default=None):

--- a/src/agent_crew/cli.py
+++ b/src/agent_crew/cli.py
@@ -907,6 +907,20 @@ def run_cmd(task: str, db: str, project: str, base: str,
             raise click.ClickException(f"project {project!r} not found in {os.path.expanduser(base)}/")
         db = state["db"]
 
+    # Pane liveness check — if any required pane is dead, refuse to run.
+    # A dead pane means tasks will be pushed but silently lost; the user must
+    # run 'crew recover' first to restore the panes.
+    if project:
+        _st = _read_state(base, project)
+        if _st:
+            _pane_ids = _st.get("pane_ids") or []
+            _dead = [p for p in _pane_ids if not _pane_alive(p)]
+            if _dead:
+                raise click.ClickException(
+                    f"Dead panes detected — run crew recover first "
+                    f"(dead: {', '.join(_dead)})"
+                )
+
     from agent_crew.loop import (
         DEFAULT_MAX_ITER,
         build_feedback,

--- a/src/agent_crew/cli.py
+++ b/src/agent_crew/cli.py
@@ -1106,6 +1106,14 @@ def run_cmd(task: str, db: str, project: str, base: str,
         if _pstate:
             _run_port = _pstate.get("port", 0)
 
+    # Fast server liveness check — avoid the 70+ second task-wait timeout when
+    # the server is simply not running (crashed or not yet started).
+    if _run_port and not _port_listening(_run_port, timeout=5.0):
+        raise click.ClickException(
+            f"Server at port {_run_port} unreachable — "
+            f"check crew status or run crew recover"
+        )
+
     # Create GitHub issue if requested
     issue_number = None
     if create_issue:

--- a/src/agent_crew/queue.py
+++ b/src/agent_crew/queue.py
@@ -319,6 +319,29 @@ class TaskQueue:
         finally:
             conn.close()
 
+    def list_all_with_status(self) -> List[dict]:
+        """Return all tasks as raw dicts including the status field."""
+        conn = self._connect()
+        try:
+            rows = conn.execute(
+                "SELECT task_id, task_type, description, branch, priority, context, status "
+                "FROM tasks ORDER BY priority ASC, created_at ASC"
+            ).fetchall()
+            return [
+                {
+                    "task_id": r["task_id"],
+                    "task_type": r["task_type"],
+                    "description": r["description"],
+                    "branch": r["branch"],
+                    "priority": r["priority"],
+                    "context": json.loads(r["context"]) if r["context"] else {},
+                    "status": r["status"],
+                }
+                for r in rows
+            ]
+        finally:
+            conn.close()
+
     def list_tasks(self, status: str = "") -> List[TaskRequest]:
         conn = self._connect()
         try:

--- a/src/agent_crew/queue.py
+++ b/src/agent_crew/queue.py
@@ -201,6 +201,18 @@ class TaskQueue:
         finally:
             conn.close()
 
+    def requeue(self, task_id: str) -> None:
+        """Roll an in_progress task back to pending so it can be dequeued again."""
+        conn = self._connect()
+        try:
+            conn.execute(
+                "UPDATE tasks SET status = 'pending' WHERE task_id = ? AND status = 'in_progress'",
+                (task_id,),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
     def cancel(self, task_id: str) -> None:
         conn = self._connect()
         try:

--- a/src/agent_crew/server.py
+++ b/src/agent_crew/server.py
@@ -324,6 +324,10 @@ def create_app(
             logger.warning(f"Failed to auto-retry task {task_id}: {e}")
             pass
 
+    @app.get("/health")
+    def health():
+        return {"status": "ok"}
+
     @app.post("/tasks", status_code=201)
     def post_task(task: TaskRequest):
         logger.info(f"POST /tasks: task_type={task.task_type}, task_id (will assign)...")

--- a/src/agent_crew/server.py
+++ b/src/agent_crew/server.py
@@ -26,6 +26,19 @@ class ResolveBody(BaseModel):
     status: Literal["approved", "rejected"]
 
 
+def _pane_alive_for_push(pane_id: str) -> bool:
+    """Return True if the tmux pane exists and can receive a push.
+
+    Uses ``tmux list-panes -t <pane_id>`` which exits non-zero if the pane is
+    gone (session killed, window closed, pane closed after crash).
+    """
+    r = subprocess.run(
+        ["tmux", "list-panes", "-t", pane_id],
+        capture_output=True,
+    )
+    return r.returncode == 0
+
+
 def _pane_has_task(pane_id: str) -> bool:
     """Return True if the pane's visible text still contains the task marker.
 
@@ -159,6 +172,15 @@ def create_app(
                 logger.warning(f"_try_push_next: agent_override {agent_override} not found in pane_map")
                 return
 
+        # Verify pane is alive before pushing — dead pane causes silent task loss.
+        if not _pane_alive_for_push(pane_id):
+            logger.error(
+                f"_try_push_next: pane {pane_id} is dead — rolling task "
+                f"{task.task_id} back to queued"
+            )
+            q().requeue(task.task_id)
+            return
+
         logger.info(f"_try_push_next: dequeued task_id={task.task_id}, calling push_fn")
         push_fn(pane_id, _format_task_message(task, port))
 
@@ -182,6 +204,15 @@ def create_app(
         if task is None:
             logger.debug(f"_try_push_discuss: no pending discuss task for agent {agent}")
             return
+        # Verify pane is alive before pushing — dead pane causes silent task loss.
+        if not _pane_alive_for_push(pane_id):
+            logger.error(
+                f"_try_push_discuss: pane {pane_id} is dead — rolling discuss task "
+                f"{task.task_id} back to queued"
+            )
+            q().requeue(task.task_id)
+            return
+
         logger.info(f"_try_push_discuss: dequeued task_id={task.task_id} for agent={agent}, calling push_fn")
         push_fn(pane_id, _format_task_message(task, port))
 

--- a/src/agent_crew/setup.py
+++ b/src/agent_crew/setup.py
@@ -212,10 +212,52 @@ def write_sessions_json(path: str, agents: list[dict]) -> None:
     session.save_sessions(path, enriched)
 
 
+def _is_port_listening(port: int) -> bool:
+    """Return True if something is accepting connections on 127.0.0.1:<port>."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.settimeout(0.2)
+        try:
+            s.connect(("127.0.0.1", port))
+            return True
+        except (ConnectionRefusedError, socket.timeout, OSError):
+            return False
+
+
+def _collect_active_ports(base: str | None = None) -> set[int]:
+    """Return ports from ~/.agent_crew/*/port files whose servers are still listening."""
+    if base is None:
+        base = os.path.expanduser("~/.agent_crew")
+    active: set[int] = set()
+    if not os.path.isdir(base):
+        return active
+    for entry in os.scandir(base):
+        if not entry.is_dir():
+            continue
+        port_file = os.path.join(entry.path, "port")
+        if not os.path.isfile(port_file):
+            continue
+        try:
+            port = int(open(port_file).read().strip())
+        except (ValueError, OSError):
+            continue
+        if _is_port_listening(port):
+            active.add(port)
+    return active
+
+
 def find_free_port(start: int = 8100) -> int:
-    """Find a free port by actually binding to it (SO_REUSEADDR off) to avoid TOCTOU."""
+    """Find a free port, blacklisting ports held by alive agent_crew servers.
+
+    Scans ~/.agent_crew/*/port files and skips any port whose server is still
+    listening. Ports from dead (non-listening) projects remain eligible.
+    Binds the socket to verify (SO_REUSEADDR off) to avoid TOCTOU.
+    """
+    blacklisted = _collect_active_ports()
     port = start
     while True:
+        if port in blacklisted:
+            port += 1
+            continue
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
             try:
                 sock.bind(("127.0.0.1", port))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,26 @@
 import shutil
 import subprocess
+from unittest.mock import patch
 
 import pytest
 from fastapi.testclient import TestClient
 
 from agent_crew.queue import TaskQueue
 from agent_crew.server import create_app
+
+
+@pytest.fixture(autouse=True)
+def _mock_pane_alive_for_push(request):
+    """Default all pane liveness checks to True in unit tests.
+
+    Tests that need to simulate dead panes use monkeypatch to override
+    agent_crew.server._pane_alive_for_push themselves.
+    """
+    if "no_pane_alive_mock" in request.keywords:
+        yield
+        return
+    with patch("agent_crew.server._pane_alive_for_push", return_value=True):
+        yield
 
 
 @pytest.fixture

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -779,3 +779,100 @@ def test_u_c44_status_falls_back_to_db_with_warning(tmp_path):
     assert "unreachable" in output or "fallback" in output or "db" in output or "offline" in output
     # Must still show DB tasks
     assert "db-only task description" in result.output
+
+
+# U-C45: crew run exits immediately with clear error when server is unreachable
+def test_u_c45_run_exits_immediately_when_server_unreachable(tmp_path):
+    """crew run must not hang 70+ seconds when the server is down. It should
+    perform a health check at startup and exit within 5 seconds with a clear
+    error message naming the port and suggesting 'crew recover'."""
+    import json
+    from agent_crew.queue import TaskQueue
+
+    db_file = str(tmp_path / "tasks.db")
+    TaskQueue(db_file)
+    state = {
+        "project": "proj45",
+        "port": 9996,  # nothing listening here
+        "db": db_file,
+        "session": "crew_proj45",
+        "agents": ["claude"],
+        "pane_ids": ["%10"],
+    }
+    (tmp_path / "proj45").mkdir()
+    (tmp_path / "proj45" / "state.json").write_text(json.dumps(state))
+
+    runner = CliRunner()
+    # Panes look alive (so pane check passes), but server is down
+    with patch("agent_crew.cli._pane_alive", return_value=True), \
+         patch("agent_crew.cli._port_listening", return_value=False):
+        result = runner.invoke(crew, [
+            "run", "do something",
+            "--project", "proj45",
+            "--base", str(tmp_path),
+        ])
+
+    assert result.exit_code != 0
+    output = result.output.lower()
+    # Must mention port and suggest recovery
+    assert "9996" in result.output
+    assert "unreachable" in output or "not running" in output or "server" in output
+    assert "recover" in output or "status" in output
+
+
+# U-C46: crew run proceeds normally when server is reachable
+def test_u_c46_run_proceeds_when_server_reachable(tmp_path):
+    """crew run must NOT emit a 'server unreachable' error when the server
+    responds to the health check."""
+    import json
+    from agent_crew.queue import TaskQueue
+
+    db_file = str(tmp_path / "tasks.db")
+    TaskQueue(db_file)
+    state = {
+        "project": "proj46",
+        "port": 9995,
+        "db": db_file,
+        "session": "crew_proj46",
+        "agents": ["claude"],
+        "pane_ids": ["%10"],
+    }
+    (tmp_path / "proj46").mkdir()
+    (tmp_path / "proj46" / "state.json").write_text(json.dumps(state))
+
+    runner = CliRunner()
+    with patch("agent_crew.cli._pane_alive", return_value=True), \
+         patch("agent_crew.cli._port_listening", return_value=True), \
+         patch("agent_crew.cli._fetch_tasks_by_status", return_value=[]), \
+         patch("agent_crew.cli.subprocess.run", return_value=MagicMock(returncode=1, stdout="")):
+        result = runner.invoke(crew, [
+            "run", "do something",
+            "--project", "proj46",
+            "--base", str(tmp_path),
+            "--timeout", "1",
+        ])
+
+    output = result.output.lower()
+    assert "server" not in output or "unreachable" not in output
+
+
+# U-C47: /health endpoint returns 200 OK with status field
+def test_u_c47_health_endpoint_returns_ok():
+    """The server must expose GET /health returning {status: ok} so that
+    crew run can perform a fast liveness check without waiting for a full
+    task operation."""
+    from fastapi.testclient import TestClient
+    from agent_crew.server import create_app
+    import tempfile, os
+
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        db_path = f.name
+    try:
+        app = create_app(db_path)
+        client = TestClient(app)
+        resp = client.get("/health")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data.get("status") == "ok"
+    finally:
+        os.unlink(db_path)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -635,3 +635,147 @@ def test_u_c41_run_proceeds_when_all_panes_alive(tmp_path):
     # Error must NOT be about dead panes — if it is, the pane check logic is wrong.
     output_lower = result.output.lower()
     assert "dead panes" not in output_lower
+
+
+# U-C42: crew status shows all terminal statuses (failed, needs_human, cancelled)
+def test_u_c42_status_shows_all_terminal_statuses(tmp_path):
+    """crew status must display failed, needs_human, and cancelled tasks, not just
+    queued/running/done. Regression: _STATUS_ALIASES omitted these statuses."""
+    import json
+    from agent_crew.queue import TaskQueue
+
+    db_file = str(tmp_path / "tasks.db")
+    tq = TaskQueue(db_file)
+
+    state = {
+        "project": "proj42",
+        "port": 9999,
+        "db": db_file,
+        "session": "crew_proj42",
+        "agents": ["claude"],
+        "pane_ids": ["%10"],
+    }
+    (tmp_path / "proj42").mkdir()
+    (tmp_path / "proj42" / "state.json").write_text(json.dumps(state))
+
+    from agent_crew.protocol import TaskRequest, TaskResult
+    import uuid
+
+    # Create tasks in terminal statuses
+    for status in ("failed", "needs_human", "cancelled"):
+        task = TaskRequest(
+            task_id=str(uuid.uuid4()),
+            task_type="implement",
+            description=f"task with status {status}",
+            branch="main",
+            priority=3,
+            context={},
+        )
+        tq.enqueue(task)
+        # Transition through in_progress to reach terminal status
+        dequeued = tq.dequeue()
+        assert dequeued is not None
+        if status != "cancelled":
+            result_obj = TaskResult(
+                task_id=dequeued.task_id,
+                status=status,
+                summary=f"finished with {status}",
+                verdict=None,
+                findings=[],
+            )
+            tq.submit_result(dequeued.task_id, result_obj)
+        else:
+            tq.cancel(dequeued.task_id)
+
+    runner = CliRunner()
+    # Server is "unreachable" — force DB fallback path
+    with patch("agent_crew.cli._fetch_tasks_by_status", side_effect=Exception("unreachable")), \
+         patch("agent_crew.cli.subprocess.run", return_value=MagicMock(returncode=1, stdout="")):
+        result = runner.invoke(crew, ["status", "proj42", "--base", str(tmp_path)])
+
+    output = result.output.lower()
+    assert "failed" in output
+    assert "needs_human" in output or "needs human" in output
+    assert "cancelled" in output
+
+
+# U-C43: crew status uses server as source of truth when reachable
+def test_u_c43_status_uses_server_when_reachable(tmp_path):
+    """When the server is reachable, crew status must query the server API,
+    not the local DB, and show all tasks returned by the server."""
+    import json
+
+    db_file = str(tmp_path / "tasks.db")
+    state = {
+        "project": "proj43",
+        "port": 9998,
+        "db": db_file,
+        "session": "crew_proj43",
+        "agents": ["claude"],
+        "pane_ids": ["%10"],
+    }
+    (tmp_path / "proj43").mkdir()
+    (tmp_path / "proj43" / "state.json").write_text(json.dumps(state))
+
+    # Server returns one task of each status
+    server_tasks = [
+        {"task_id": "t1", "task_type": "implement", "description": "server-task-pending",
+         "branch": "main", "priority": 3, "context": {}, "status": "pending"},
+        {"task_id": "t2", "task_type": "review", "description": "server-task-failed",
+         "branch": "main", "priority": 3, "context": {}, "status": "failed"},
+    ]
+
+    def mock_fetch(port, status):
+        return [t for t in server_tasks if t["status"] == status]
+
+    runner = CliRunner()
+    with patch("agent_crew.cli._fetch_tasks_by_status", side_effect=mock_fetch), \
+         patch("agent_crew.cli.subprocess.run", return_value=MagicMock(returncode=1, stdout="")):
+        result = runner.invoke(crew, ["status", "proj43", "--base", str(tmp_path)])
+
+    assert "server-task-pending" in result.output
+    assert "server-task-failed" in result.output
+
+
+# U-C44: crew status falls back to DB with warning when server is unreachable
+def test_u_c44_status_falls_back_to_db_with_warning(tmp_path):
+    """When the server is unreachable, crew status must fall back to the local DB
+    and print a warning so the operator knows the data may be stale."""
+    import json
+    from agent_crew.queue import TaskQueue
+    from agent_crew.protocol import TaskRequest
+
+    db_file = str(tmp_path / "tasks.db")
+    tq = TaskQueue(db_file)
+
+    pending_task = TaskRequest(
+        task_id="db-task-001",
+        task_type="implement",
+        description="db-only task description",
+        branch="main",
+        priority=2,
+        context={},
+    )
+    tq.enqueue(pending_task)
+
+    state = {
+        "project": "proj44",
+        "port": 9997,
+        "db": db_file,
+        "session": "crew_proj44",
+        "agents": ["claude"],
+        "pane_ids": ["%10"],
+    }
+    (tmp_path / "proj44").mkdir()
+    (tmp_path / "proj44" / "state.json").write_text(json.dumps(state))
+
+    runner = CliRunner()
+    with patch("agent_crew.cli._fetch_tasks_by_status", side_effect=Exception("connection refused")), \
+         patch("agent_crew.cli.subprocess.run", return_value=MagicMock(returncode=1, stdout="")):
+        result = runner.invoke(crew, ["status", "proj44", "--base", str(tmp_path)])
+
+    output = result.output.lower()
+    # Must warn about server being unreachable / data being from DB
+    assert "unreachable" in output or "fallback" in output or "db" in output or "offline" in output
+    # Must still show DB tasks
+    assert "db-only task description" in result.output

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -876,3 +876,69 @@ def test_u_c47_health_endpoint_returns_ok():
         assert data.get("status") == "ok"
     finally:
         os.unlink(db_path)
+
+
+# U-C48: crew setup --help shows single-agent usage example
+def test_u_c48_setup_help_shows_single_agent_example():
+    """crew setup --help must include an example showing --agents for single-agent
+    mode so users know they can spawn only one agent."""
+    runner = CliRunner()
+    result = runner.invoke(crew, ["setup", "--help"])
+    assert result.exit_code == 0
+    # The help text must hint at single-agent usage with --agents
+    assert "--agents" in result.output
+    # Must show a concrete agent name as example (codex or claude)
+    assert "codex" in result.output or "claude" in result.output
+    # Must show the pattern "crew setup" or similar context
+    assert "single" in result.output.lower() or "example" in result.output.lower() or "e.g." in result.output.lower()
+
+
+# U-C49: crew setup prints a Tip line after completing successfully
+def test_u_c49_setup_prints_tip_after_completion(tmp_path):
+    """After a successful setup, cli.py must print a Tip line mentioning --agents
+    so users discover the single-agent mode."""
+
+    def _fake_run(args, **_kw):
+        cmd = args[1] if len(args) > 1 else ""
+        if cmd == "display-message":
+            # First call returns session:window, subsequent calls return numeric values
+            joined = " ".join(args)
+            if "#S:#I" in joined:
+                return MagicMock(returncode=0, stdout="crew:0\n", stderr="")
+            if "window_width" in joined:
+                return MagicMock(returncode=0, stdout="200\n", stderr="")
+            if "pane_width" in joined:
+                return MagicMock(returncode=0, stdout="100\n", stderr="")
+            return MagicMock(returncode=0, stdout="crew\n", stderr="")
+        if cmd == "split-window":
+            return MagicMock(returncode=0, stdout="%99\n", stderr="")
+        if cmd == "select-layout":
+            return MagicMock(returncode=0, stdout="", stderr="")
+        if cmd in ("list-panes", "list-windows"):
+            return MagicMock(returncode=0, stdout="0\n", stderr="")
+        return MagicMock(returncode=0, stdout="", stderr="")
+
+    mock_proc = MagicMock()
+    mock_proc.pid = 12345
+
+    runner = CliRunner(env={"TMUX_PANE": "%0"})
+    with patch("agent_crew.cli.setup_module.validate_git_repo", return_value=True), \
+         patch("agent_crew.cli._read_state", return_value=None), \
+         patch("agent_crew.cli.setup_module.find_free_port", return_value=19999), \
+         patch("agent_crew.cli.setup_module.write_port_file"), \
+         patch("agent_crew.cli.setup_module.create_worktrees", return_value={"claude": str(tmp_path / "wt")}), \
+         patch("agent_crew.cli.setup_module.write_instruction_files"), \
+         patch("agent_crew.cli.setup_module.write_sessions_json"), \
+         patch("agent_crew.cli.subprocess.run", side_effect=_fake_run), \
+         patch("agent_crew.cli.subprocess.Popen", return_value=mock_proc), \
+         patch("agent_crew.cli._port_listening", return_value=True), \
+         patch("agent_crew.cli.setup_module.pretrust_claude_worktree"), \
+         patch("agent_crew.cli.setup_module.start_agents_in_panes"), \
+         patch("agent_crew.cli._write_state"), \
+         patch("os.getcwd", return_value=str(tmp_path)):
+        result = runner.invoke(crew, ["setup", "myproj", "--base", str(tmp_path)])
+
+    assert result.exit_code == 0, result.output
+    output = result.output.lower()
+    assert "tip" in output
+    assert "--agents" in result.output

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -572,3 +572,66 @@ def test_u_c39_auto_detect_base_is_file(tmp_path):
 
     result = _auto_detect_project(str(file_path))
     assert result is None
+
+
+# U-C40: crew run exits early with 'Dead panes detected' when a required pane is dead
+def test_u_c40_run_exits_on_dead_pane(tmp_path):
+    """crew run must check pane liveness at startup. If any required pane is
+    dead, it must exit immediately with an error that tells the user to recover."""
+    import json
+    db_file = str(tmp_path / "tasks.db")
+    state = {
+        "project": "test_proj",
+        "port": 0,
+        "db": db_file,
+        "session": "crew_test_proj",
+        "agents": ["claude", "codex"],
+        "pane_ids": ["%10", "%20"],
+    }
+    (tmp_path / "test_proj").mkdir()
+    (tmp_path / "test_proj" / "state.json").write_text(json.dumps(state))
+
+    runner = CliRunner()
+    with patch("agent_crew.cli._pane_alive", return_value=False):
+        result = runner.invoke(crew, [
+            "run", "do something",
+            "--project", "test_proj",
+            "--base", str(tmp_path),
+        ])
+
+    assert result.exit_code != 0
+    assert "dead" in result.output.lower() or "recover" in result.output.lower()
+
+
+# U-C41: crew run proceeds past pane check when all panes are alive
+def test_u_c41_run_proceeds_when_all_panes_alive(tmp_path):
+    """crew run must not emit a 'dead panes' error when all panes are alive."""
+    import json
+    from agent_crew.queue import TaskQueue
+
+    db_file = str(tmp_path / "tasks.db")
+    TaskQueue(db_file)  # initialize DB schema
+    state = {
+        "project": "test_proj2",
+        "port": 0,
+        "db": db_file,
+        "session": "crew_test_proj2",
+        "agents": ["claude"],
+        "pane_ids": ["%10"],
+    }
+    (tmp_path / "test_proj2").mkdir()
+    (tmp_path / "test_proj2" / "state.json").write_text(json.dumps(state))
+
+    runner = CliRunner()
+    # Pane alive — pane check passes. Use timeout=1 so the wait loop exits fast.
+    with patch("agent_crew.cli._pane_alive", return_value=True):
+        result = runner.invoke(crew, [
+            "run", "do something",
+            "--project", "test_proj2",
+            "--base", str(tmp_path),
+            "--timeout", "1",
+        ])
+
+    # Error must NOT be about dead panes — if it is, the pane check logic is wrong.
+    output_lower = result.output.lower()
+    assert "dead panes" not in output_lower

--- a/tests/unit/test_server_push.py
+++ b/tests/unit/test_server_push.py
@@ -415,3 +415,75 @@ def test_u_sp17_auto_review_task_queryable(tmp_db):
         review = review_tasks[0]
         assert "impl-004" in str(review.get("context", {}))
         assert "Fix bug Y" in review["description"]
+
+
+# U-SP18: dead pane before push → task rolled back to queued, push_fn not called
+def test_u_sp18_dead_pane_rolls_back_task_to_queued(tmp_db, monkeypatch):
+    """If the target pane is dead, the dequeued task must be put back to 'queued'
+    and push_fn must NOT be called."""
+    from unittest.mock import MagicMock
+    from agent_crew.server import _pane_alive_for_push
+
+    # Patch pane liveness check to always return False (dead pane)
+    monkeypatch.setattr("agent_crew.server._pane_alive_for_push", lambda pane_id: False)
+
+    push = RecordingPush()
+    app = create_app(
+        db_path=tmp_db,
+        pane_map={"implementer": "%dead"},
+        port=8100,
+        push_fn=push,
+    )
+    with TestClient(app) as client:
+        client.post("/tasks", json=_task_payload("t-dead", "implement"))
+
+    # push_fn must NOT have been called
+    assert push.calls == []
+
+    # Task must be back in queued state (not in_progress or lost)
+    from agent_crew.queue import TaskQueue
+    q = TaskQueue(tmp_db)
+    tasks = q.list_tasks(status="pending")
+    task_ids = [t.task_id for t in tasks]
+    assert "t-dead" in task_ids
+
+
+# U-SP19: dead pane on result submission → next task rolled back, push_fn not called
+def test_u_sp19_dead_pane_on_result_next_task_requeued(tmp_db, monkeypatch):
+    """When a result triggers the next push but the pane is now dead, the next
+    task must be rolled back to queued and push_fn not called again."""
+    from agent_crew.server import _pane_alive_for_push
+
+    call_count = {"n": 0}
+
+    def pane_alive_side_effect(pane_id):
+        # First call (for t1 initial push) → alive; subsequent calls → dead
+        call_count["n"] += 1
+        return call_count["n"] == 1
+
+    monkeypatch.setattr("agent_crew.server._pane_alive_for_push", pane_alive_side_effect)
+
+    push = RecordingPush()
+    app = create_app(
+        db_path=tmp_db,
+        pane_map={"implementer": "%100"},
+        port=8100,
+        push_fn=push,
+    )
+    with TestClient(app) as client:
+        client.post("/tasks", json=_task_payload("t1", "implement"))
+        client.post("/tasks", json=_task_payload("t2", "implement"))
+        assert len(push.calls) == 1  # only t1 pushed (pane alive)
+
+        # Submit t1 result; pane now dead when trying to push t2
+        resp = client.post("/tasks/t1/result", json=_result_payload("t1"))
+        assert resp.status_code == 200
+
+    # t2 must NOT have been pushed
+    assert len(push.calls) == 1
+
+    # t2 must be back in queued/pending state
+    from agent_crew.queue import TaskQueue
+    q = TaskQueue(tmp_db)
+    tasks = q.list_tasks(status="pending")
+    assert any(t.task_id == "t2" for t in tasks)

--- a/tests/unit/test_setup.py
+++ b/tests/unit/test_setup.py
@@ -1,6 +1,8 @@
 from unittest.mock import MagicMock, patch
 
 from agent_crew.setup import (
+    _collect_active_ports,
+    _is_port_listening,
     create_worktrees,
     find_free_port,
     pretrust_claude_worktree,
@@ -61,14 +63,15 @@ def test_u_se04_write_sessions_json(tmp_path):
         assert "cmd" in agent
 
 
-# U-SE05: find_free_port — 8100 bind fails, returns 8101
+# U-SE05: find_free_port — 8100 bind fails (OS rejects it), returns 8101
 def test_u_se05_find_free_port():
     mock_sock = MagicMock()
     mock_sock.__enter__ = lambda s: s
     mock_sock.__exit__ = MagicMock(return_value=False)
     mock_sock.bind.side_effect = lambda addr: (_ for _ in ()).throw(OSError()) if addr[1] == 8100 else None
 
-    with patch("agent_crew.setup.socket.socket", return_value=mock_sock):
+    with patch("agent_crew.setup._collect_active_ports", return_value=set()), \
+         patch("agent_crew.setup.socket.socket", return_value=mock_sock):
         port = find_free_port(start=8100)
     assert port == 8101
 
@@ -194,3 +197,89 @@ def test_u_se14_pretrust_noop_when_no_claude_worktree(tmp_path):
         pretrust_claude_worktree({"codex": str(tmp_path / "wt_codex")})
     # File untouched.
     assert _json.loads(config.read_text()) == original
+
+
+# U-SE15: find_free_port skips ports from active project port files
+def test_u_se15_find_free_port_skips_active_port_files():
+    """Port 8100 is referenced by an active server — must be skipped without bind attempt."""
+    mock_sock = MagicMock()
+    mock_sock.__enter__ = lambda s: s
+    mock_sock.__exit__ = MagicMock(return_value=False)
+    mock_sock.bind.side_effect = None  # 8101 binds fine
+
+    with patch("agent_crew.setup._collect_active_ports", return_value={8100}), \
+         patch("agent_crew.setup.socket.socket", return_value=mock_sock):
+        port = find_free_port(start=8100)
+
+    assert port == 8101
+    called_ports = [call[0][0][1] for call in mock_sock.bind.call_args_list]
+    assert 8100 not in called_ports
+
+
+# U-SE16: find_free_port reuses port from dead project (stale port file, no server)
+def test_u_se16_find_free_port_reuses_dead_project_port():
+    """Port 8100 in a stale port file but server is dead — must be eligible."""
+    mock_sock = MagicMock()
+    mock_sock.__enter__ = lambda s: s
+    mock_sock.__exit__ = MagicMock(return_value=False)
+    mock_sock.bind.side_effect = None  # 8100 binds fine
+
+    with patch("agent_crew.setup._collect_active_ports", return_value=set()), \
+         patch("agent_crew.setup.socket.socket", return_value=mock_sock):
+        port = find_free_port(start=8100)
+
+    assert port == 8100
+
+
+# U-SE17: _collect_active_ports scans all ~/.agent_crew/*/port files
+def test_u_se17_collect_active_ports_scans_all_port_files(tmp_path):
+    """Only ports whose servers are listening are returned."""
+    (tmp_path / "proj_a").mkdir()
+    (tmp_path / "proj_a" / "port").write_text("8100")
+    (tmp_path / "proj_b").mkdir()
+    (tmp_path / "proj_b" / "port").write_text("8101")
+    (tmp_path / "proj_c").mkdir()  # no port file
+
+    with patch("agent_crew.setup._is_port_listening", side_effect=lambda p: p == 8100):
+        active = _collect_active_ports(base=str(tmp_path))
+
+    assert active == {8100}
+    assert 8101 not in active
+
+
+# U-SE18: _collect_active_ports silently skips corrupt port files
+def test_u_se18_collect_active_ports_handles_corrupt_port_files(tmp_path):
+    """A port file with non-integer content is silently skipped."""
+    (tmp_path / "bad_proj").mkdir()
+    (tmp_path / "bad_proj" / "port").write_text("not-a-number")
+    (tmp_path / "good_proj").mkdir()
+    (tmp_path / "good_proj" / "port").write_text("8200")
+
+    with patch("agent_crew.setup._is_port_listening", return_value=True):
+        active = _collect_active_ports(base=str(tmp_path))
+
+    assert 8200 in active  # no exception for bad_proj
+
+
+# U-SE19: _is_port_listening returns True when a server is bound
+def test_u_se19_is_port_listening_returns_true():
+    import socket as real_socket
+    server = real_socket.socket(real_socket.AF_INET, real_socket.SOCK_STREAM)
+    server.setsockopt(real_socket.SOL_SOCKET, real_socket.SO_REUSEADDR, 1)
+    server.bind(("127.0.0.1", 0))
+    server.listen(1)
+    port = server.getsockname()[1]
+    try:
+        assert _is_port_listening(port) is True
+    finally:
+        server.close()
+
+
+# U-SE20: _is_port_listening returns False for an unbound port
+def test_u_se20_is_port_listening_returns_false():
+    import socket as real_socket
+    s = real_socket.socket(real_socket.AF_INET, real_socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    assert _is_port_listening(port) is False


### PR DESCRIPTION
## Summary
- `find_free_port()`가 `~/.agent_crew/*/port` 파일을 스캔해서 살아있는 서버가 사용 중인 포트를 블랙리스트에 추가
- 죽은 프로젝트의 포트(서버 미응답)는 재사용 허용
- `_is_port_listening()`, `_collect_active_ports()` 헬퍼 추가 + 유닛 테스트 6개 (U-SE15–U-SE20)

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)