### PR TITLE
fix(#69): auto-triage repo routing, cross-project review guard, cancel orphaning

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,6 @@
+import sys
+import os
+
+# Ensure this worktree's src/ is first on sys.path, overriding any system-installed
+# agent_crew package. Needed when pytest is invoked from outside the repo root.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "src"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ where = ["src"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+pythonpath = ["src"]
 markers = [
   "unit: unit tests",
   "integration: integration tests",

--- a/src/agent_crew/cli.py
+++ b/src/agent_crew/cli.py
@@ -224,6 +224,7 @@ _STATUS_ALIASES = (
     ("failed", "failed"),
     ("needs_human", "needs_human"),
     ("cancelled", "cancelled"),
+    ("orphaned", "orphaned"),
 )
 # Reverse map: DB status → display label (used in DB fallback)
 _DB_STATUS_TO_DISPLAY = {api: disp for disp, api in _STATUS_ALIASES}
@@ -1523,6 +1524,17 @@ def triage(repo: str, db: str, project: str, base: str, branch: str,
 
     from agent_crew import triage as triage_module
     from agent_crew.queue import TaskQueue
+
+    # Validate --repo matches the project's git origin to prevent cross-project enqueue.
+    if project:
+        try:
+            project_path = setup_module.resolve_project_path(project)
+        except RuntimeError:
+            project_path = ""
+        if project_path:
+            ok, err_msg = triage_module.validate_repo_origin(repo, project_path)
+            if not ok:
+                raise click.ClickException(err_msg)
 
     queue = TaskQueue(db)
 

--- a/src/agent_crew/protocol.py
+++ b/src/agent_crew/protocol.py
@@ -18,6 +18,7 @@ class TaskRequest:
     branch: str = ""
     priority: int = 3
     context: dict = field(default_factory=dict)
+    project: str = ""  # owner/name form, e.g. "org/myrepo". Used to detect cross-project routing.
 
     def __post_init__(self):
         if self.task_type not in _VALID_TASK_TYPES:

--- a/src/agent_crew/queue.py
+++ b/src/agent_crew/queue.py
@@ -214,10 +214,43 @@ class TaskQueue:
             conn.close()
 
     def cancel(self, task_id: str) -> None:
+        """Cancel a task. Dependent tasks (prev_task_id points to task_id) are marked
+        'orphaned' rather than cancelled — operators can manually cancel them if desired."""
         conn = self._connect()
         try:
             conn.execute("UPDATE tasks SET status = 'cancelled' WHERE task_id = ?", (task_id,))
+            # Mark pending dependents as orphaned (not cancelled) so the operator
+            # can see them and decide whether to cancel or reassign.
+            conn.execute(
+                """
+                UPDATE tasks SET status = 'orphaned'
+                WHERE status IN ('pending', 'in_progress')
+                AND json_extract(context, '$.prev_task_id') = ?
+                """,
+                (task_id,),
+            )
             conn.commit()
+        finally:
+            conn.close()
+
+    def list_orphaned(self) -> List[TaskRequest]:
+        """Return all tasks with status='orphaned'."""
+        conn = self._connect()
+        try:
+            rows = conn.execute(
+                "SELECT * FROM tasks WHERE status = 'orphaned' ORDER BY priority ASC, created_at ASC"
+            ).fetchall()
+            return [
+                TaskRequest(
+                    task_id=r["task_id"],
+                    task_type=r["task_type"],
+                    description=r["description"],
+                    branch=r["branch"],
+                    priority=r["priority"],
+                    context=json.loads(r["context"]),
+                )
+                for r in rows
+            ]
         finally:
             conn.close()
 

--- a/src/agent_crew/queue.py
+++ b/src/agent_crew/queue.py
@@ -43,12 +43,15 @@ CREATE TABLE IF NOT EXISTS tasks (
     context     TEXT NOT NULL DEFAULT '{}',
     status      TEXT NOT NULL DEFAULT 'pending',
     created_at  REAL NOT NULL,
+    project     TEXT NOT NULL DEFAULT '',
     summary     TEXT,
     verdict     TEXT,
     findings    TEXT,
     pr_number   INTEGER
 )
 """
+
+_DDL_MIGRATE_PROJECT = "ALTER TABLE tasks ADD COLUMN project TEXT NOT NULL DEFAULT ''"
 
 _DDL_CHECKPOINTS = """
 CREATE TABLE IF NOT EXISTS checkpoints (
@@ -80,6 +83,11 @@ class TaskQueue:
         conn.execute(_DDL)
         conn.execute(_DDL_GATES)
         conn.execute(_DDL_CHECKPOINTS)
+        # Migrate existing DBs: add project column if absent
+        try:
+            conn.execute(_DDL_MIGRATE_PROJECT)
+        except Exception:
+            pass  # column already exists
         # Create indexes for performance
         for idx_stmt in _DDL_INDEXES.strip().split('\n'):
             if idx_stmt.strip():
@@ -97,8 +105,8 @@ class TaskQueue:
         try:
             conn.execute(
                 """
-                INSERT INTO tasks (task_id, task_type, description, branch, priority, context, status, created_at)
-                VALUES (?, ?, ?, ?, ?, ?, 'pending', ?)
+                INSERT INTO tasks (task_id, task_type, description, branch, priority, context, status, created_at, project)
+                VALUES (?, ?, ?, ?, ?, ?, 'pending', ?, ?)
                 """,
                 (
                     task.task_id,
@@ -108,6 +116,7 @@ class TaskQueue:
                     task.priority,
                     json.dumps(task.context),
                     time.time(),
+                    task.project,
                 ),
             )
             conn.commit()
@@ -160,6 +169,7 @@ class TaskQueue:
                 branch=row["branch"],
                 priority=row["priority"],
                 context=json.loads(row["context"]),
+                project=row["project"] if row["project"] else "",
             )
         except Exception:
             try:
@@ -248,6 +258,7 @@ class TaskQueue:
                     branch=r["branch"],
                     priority=r["priority"],
                     context=json.loads(r["context"]),
+                    project=r["project"] if r["project"] else "",
                 )
                 for r in rows
             ]
@@ -325,6 +336,7 @@ class TaskQueue:
                 branch=chosen["branch"],
                 priority=chosen["priority"],
                 context=json.loads(chosen["context"]),
+                project=chosen["project"] if chosen["project"] else "",
             )
         except Exception:
             try:
@@ -353,11 +365,11 @@ class TaskQueue:
             conn.close()
 
     def list_all_with_status(self) -> List[dict]:
-        """Return all tasks as raw dicts including the status field."""
+        """Return all tasks as raw dicts including the status and project fields."""
         conn = self._connect()
         try:
             rows = conn.execute(
-                "SELECT task_id, task_type, description, branch, priority, context, status "
+                "SELECT task_id, task_type, description, branch, priority, context, status, project "
                 "FROM tasks ORDER BY priority ASC, created_at ASC"
             ).fetchall()
             return [
@@ -369,6 +381,7 @@ class TaskQueue:
                     "priority": r["priority"],
                     "context": json.loads(r["context"]) if r["context"] else {},
                     "status": r["status"],
+                    "project": r["project"] if r["project"] else "",
                 }
                 for r in rows
             ]
@@ -395,6 +408,7 @@ class TaskQueue:
                     branch=r["branch"],
                     priority=r["priority"],
                     context=json.loads(r["context"]),
+                    project=r["project"] if r["project"] else "",
                 )
                 for r in rows
             ]

--- a/src/agent_crew/server.py
+++ b/src/agent_crew/server.py
@@ -118,12 +118,14 @@ def create_app(
     pane_map: Optional[dict] = None,
     port: int = 0,
     push_fn: Callable[[str, str], None] = _default_push,
+    project: Optional[str] = None,
 ) -> FastAPI:
     """
     pane_map: {role: pane_id} — e.g. {"implementer": "%475"}. If None, push is disabled.
     port: the HTTP port the server is listening on (embedded in task push messages so
     agents know where to POST results). Defaults to 0 (messages will say port 0).
     push_fn: injectable for testing.
+    project: optional project name used to guard against cross-project review routing.
     """
     state: dict = {}
 
@@ -226,7 +228,19 @@ def create_app(
                 return
             impl_task = impl_tasks[0]
 
-            # Create review task with same description/branch, reference to impl task
+            # Cross-project guard: if the impl task carries a project tag and the
+            # server was started for a different project, skip auto-review to
+            # prevent misrouting tasks across project queues.
+            impl_project = impl_task.context.get("project") if isinstance(impl_task.context, dict) else None
+            if impl_project and project and impl_project != project:
+                logger.warning(
+                    f"_auto_enqueue_review: skipping cross-project review — "
+                    f"impl project={impl_project!r}, server project={project!r}"
+                )
+                return
+
+            # Create review task with same description/branch, reference to impl task.
+            # Inherit project from impl task so downstream guards can detect misrouting.
             review_context = {
                 "checklist_layers": ["test_quality", "code_quality", "business_gap"],
                 "reviewer_rejects_happy_path_only": True,
@@ -238,6 +252,8 @@ def create_app(
                 ),
                 "prev_task_id": impl_task_id,
             }
+            if impl_project:
+                review_context["project"] = impl_project
             review_req = TaskRequest(
                 task_id=f"review-{uuid.uuid4().hex[:8]}",
                 task_type="review",

--- a/src/agent_crew/server.py
+++ b/src/agent_crew/server.py
@@ -228,10 +228,10 @@ def create_app(
                 return
             impl_task = impl_tasks[0]
 
-            # Cross-project guard: if the impl task carries a project tag and the
-            # server was started for a different project, skip auto-review to
+            # Cross-project guard: if the impl task carries a top-level project tag
+            # and the server was started for a different project, skip auto-review to
             # prevent misrouting tasks across project queues.
-            impl_project = impl_task.context.get("project") if isinstance(impl_task.context, dict) else None
+            impl_project = impl_task.project  # top-level field, typed
             if impl_project and project and impl_project != project:
                 logger.warning(
                     f"_auto_enqueue_review: skipping cross-project review — "
@@ -240,7 +240,8 @@ def create_app(
                 return
 
             # Create review task with same description/branch, reference to impl task.
-            # Inherit project from impl task so downstream guards can detect misrouting.
+            # Inherit top-level project from impl task so the cross-project guard works
+            # for subsequent hops in the pipeline (review → test).
             review_context = {
                 "checklist_layers": ["test_quality", "code_quality", "business_gap"],
                 "reviewer_rejects_happy_path_only": True,
@@ -252,14 +253,13 @@ def create_app(
                 ),
                 "prev_task_id": impl_task_id,
             }
-            if impl_project:
-                review_context["project"] = impl_project
             review_req = TaskRequest(
                 task_id=f"review-{uuid.uuid4().hex[:8]}",
                 task_type="review",
                 description=impl_task.description,
                 branch=impl_task.branch,
                 context=review_context,
+                project=impl_project,  # top-level field propagated
             )
             q().enqueue(review_req)
             # Try to push the newly enqueued review task to reviewer pane

--- a/src/agent_crew/triage.py
+++ b/src/agent_crew/triage.py
@@ -51,6 +51,45 @@ def parse_response(text: str) -> dict | None:
     }
 
 
+def get_project_git_origin(project_path: str) -> str | None:
+    """Return the 'origin' remote URL for the git repo at project_path, or None."""
+    result = subprocess.run(
+        ["git", "-C", project_path, "remote", "get-url", "origin"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
+def validate_repo_origin(repo: str, project_path: str) -> tuple[bool, str]:
+    """Check that --repo matches the git remote origin of project_path.
+
+    repo: owner/name form (e.g. 'org/myrepo')
+    Returns (True, "") on match, (False, error_message) on mismatch.
+    """
+    origin = get_project_git_origin(project_path)
+    if origin is None:
+        return True, ""  # no remote configured — can't validate, allow through
+    # Normalise: strip trailing .git, extract owner/name from URL
+    normalised = origin.rstrip("/")
+    if normalised.endswith(".git"):
+        normalised = normalised[:-4]
+    # Both "https://github.com/org/repo" and "git@github.com:org/repo" forms
+    # end with "/org/repo" or ":org/repo" — take the last two path components.
+    parts = normalised.replace(":", "/").rstrip("/").split("/")
+    if len(parts) >= 2:
+        origin_slug = f"{parts[-2]}/{parts[-1]}"
+    else:
+        origin_slug = normalised
+    if repo == origin_slug:
+        return True, ""
+    return False, (
+        f"repo mismatch: --repo {repo} but project origin is {origin_slug} ({origin})"
+    )
+
+
 def fetch_issues_from_gh(repo: str) -> list[dict]:
     result = subprocess.run(
         ["gh", "issue", "list", "--repo", repo, "--json", "number,title,labels"],

--- a/tests/unit/test_queue.py
+++ b/tests/unit/test_queue.py
@@ -249,3 +249,98 @@ def test_u_q17_gate_resolve_already_resolved(q):
     q.resolve_gate("g-001", approved=True)
     with pytest.raises(ValueError):
         q.resolve_gate("g-001", approved=True)
+
+
+# U-Q18: cancel() marks dependent tasks (context.prev_task_id) as 'orphaned'
+def test_u_q18_cancel_orphans_dependents(q):
+    """When an impl task is cancelled, any pending tasks whose context.prev_task_id
+    references the cancelled task must become 'orphaned', not 'cancelled'.
+    This preserves the review chain visibly without silently dropping work."""
+    impl = TaskRequest(
+        task_id="impl-parent",
+        task_type="implement",
+        description="parent task",
+        context={},
+    )
+    review = TaskRequest(
+        task_id="review-child",
+        task_type="review",
+        description="review of parent",
+        context={"prev_task_id": "impl-parent"},
+    )
+    q.enqueue(impl)
+    q.enqueue(review)
+
+    q.cancel("impl-parent")
+
+    # Parent is cancelled
+    cancelled = q.list_tasks(status="cancelled")
+    assert any(t.task_id == "impl-parent" for t in cancelled)
+
+    # Dependent is orphaned, NOT cancelled
+    orphaned = q.list_tasks(status="orphaned")
+    assert any(t.task_id == "review-child" for t in orphaned)
+
+    # Dependent is NOT in cancelled list
+    assert not any(t.task_id == "review-child" for t in cancelled)
+
+
+# U-Q19: cancel() does NOT cascade 'cancelled' status to dependents
+def test_u_q19_cancel_does_not_cascade_cancelled_status(q):
+    """Cancelling a task must not set dependents to 'cancelled'.
+    Only the target task itself becomes 'cancelled'."""
+    impl = TaskRequest(
+        task_id="impl-x",
+        task_type="implement",
+        description="impl x",
+        context={},
+    )
+    review = TaskRequest(
+        task_id="review-x",
+        task_type="review",
+        description="review x",
+        context={"prev_task_id": "impl-x"},
+    )
+    test_task = TaskRequest(
+        task_id="test-x",
+        task_type="test",
+        description="test x",
+        context={"prev_task_id": "review-x"},
+    )
+    q.enqueue(impl)
+    q.enqueue(review)
+    q.enqueue(test_task)
+
+    q.cancel("impl-x")
+
+    cancelled = q.list_tasks(status="cancelled")
+    cancelled_ids = {t.task_id for t in cancelled}
+    # Only impl-x is cancelled
+    assert "impl-x" in cancelled_ids
+    assert "review-x" not in cancelled_ids
+    assert "test-x" not in cancelled_ids
+
+
+# U-Q20: list_orphaned() returns only orphaned tasks
+def test_u_q20_list_orphaned(q):
+    """list_orphaned() must return tasks with status='orphaned' only."""
+    impl = TaskRequest(
+        task_id="impl-orphan-test",
+        task_type="implement",
+        description="impl",
+        context={},
+    )
+    review = TaskRequest(
+        task_id="review-orphan-test",
+        task_type="review",
+        description="review",
+        context={"prev_task_id": "impl-orphan-test"},
+    )
+    q.enqueue(impl)
+    q.enqueue(review)
+
+    q.cancel("impl-orphan-test")
+
+    orphaned = q.list_orphaned()
+    assert len(orphaned) == 1
+    assert orphaned[0].task_id == "review-orphan-test"

--- a/tests/unit/test_server_push.py
+++ b/tests/unit/test_server_push.py
@@ -487,3 +487,59 @@ def test_u_sp19_dead_pane_on_result_next_task_requeued(tmp_db, monkeypatch):
     q = TaskQueue(tmp_db)
     tasks = q.list_tasks(status="pending")
     assert any(t.task_id == "t2" for t in tasks)
+
+
+# U-SP20: _auto_enqueue_review inherits project from impl task context
+def test_u_sp20_auto_enqueue_review_inherits_project(tmp_db):
+    """When _auto_enqueue_review creates a review task for an impl task,
+    it must copy context.project from the impl task into the review task context.
+    This ensures cross-project routing can be detected."""
+    push = RecordingPush()
+    app = create_app(
+        db_path=tmp_db,
+        pane_map={"implementer": "%1", "reviewer": "%2"},
+        push_fn=push,
+        project="project_a",
+    )
+    with TestClient(app) as client:
+        # Enqueue impl task with project in context
+        impl = dict(_task_payload("impl-sp20"), context={"project": "project_a"})
+        client.post("/tasks", json=impl)
+
+        # Submit completed result → triggers _auto_enqueue_review
+        r = client.post("/tasks/impl-sp20/result", json=_result_payload("impl-sp20"))
+        assert r.status_code == 200
+
+    # The auto-created review task must carry project=project_a in context
+    from agent_crew.queue import TaskQueue
+    q = TaskQueue(tmp_db)
+    review_tasks = [t for t in q.list_tasks() if t.task_type == "review"]
+    assert len(review_tasks) == 1
+    assert review_tasks[0].context.get("project") == "project_a"
+
+
+# U-SP21: _auto_enqueue_review rejects cross-project impl tasks
+def test_u_sp21_auto_enqueue_review_rejects_cross_project(tmp_db):
+    """When the impl task's context.project doesn't match the server's project,
+    _auto_enqueue_review must NOT enqueue a review task (skip silently).
+    This prevents cross-project review routing."""
+    push = RecordingPush()
+    app = create_app(
+        db_path=tmp_db,
+        pane_map={"implementer": "%1", "reviewer": "%2"},
+        push_fn=push,
+        project="project_a",   # server is for project_a
+    )
+    with TestClient(app) as client:
+        # Enqueue impl task belonging to a DIFFERENT project
+        impl = dict(_task_payload("impl-sp21"), context={"project": "project_b"})
+        client.post("/tasks", json=impl)
+
+        # Submit result — should NOT auto-enqueue a review task
+        r = client.post("/tasks/impl-sp21/result", json=_result_payload("impl-sp21"))
+        assert r.status_code == 200
+
+    from agent_crew.queue import TaskQueue
+    q = TaskQueue(tmp_db)
+    review_tasks = [t for t in q.list_tasks() if t.task_type == "review"]
+    assert len(review_tasks) == 0, "cross-project review task must not be enqueued"

--- a/tests/unit/test_server_push.py
+++ b/tests/unit/test_server_push.py
@@ -12,7 +12,7 @@ from fastapi.testclient import TestClient
 from agent_crew.server import create_app
 
 
-def _task_payload(task_id="t1", task_type="implement", description="do work", priority=3):
+def _task_payload(task_id="t1", task_type="implement", description="do work", priority=3, project=""):
     return {
         "task_id": task_id,
         "task_type": task_type,
@@ -20,6 +20,7 @@ def _task_payload(task_id="t1", task_type="implement", description="do work", pr
         "branch": "main",
         "priority": priority,
         "context": {},
+        "project": project,
     }
 
 
@@ -502,20 +503,20 @@ def test_u_sp20_auto_enqueue_review_inherits_project(tmp_db):
         project="project_a",
     )
     with TestClient(app) as client:
-        # Enqueue impl task with project in context
-        impl = dict(_task_payload("impl-sp20"), context={"project": "project_a"})
+        # Enqueue impl task with top-level project field
+        impl = _task_payload("impl-sp20", project="project_a")
         client.post("/tasks", json=impl)
 
         # Submit completed result → triggers _auto_enqueue_review
         r = client.post("/tasks/impl-sp20/result", json=_result_payload("impl-sp20"))
         assert r.status_code == 200
 
-    # The auto-created review task must carry project=project_a in context
+    # The auto-created review task must carry project="project_a" as a top-level field
     from agent_crew.queue import TaskQueue
     q = TaskQueue(tmp_db)
     review_tasks = [t for t in q.list_tasks() if t.task_type == "review"]
     assert len(review_tasks) == 1
-    assert review_tasks[0].context.get("project") == "project_a"
+    assert review_tasks[0].project == "project_a"
 
 
 # U-SP21: _auto_enqueue_review rejects cross-project impl tasks
@@ -531,8 +532,8 @@ def test_u_sp21_auto_enqueue_review_rejects_cross_project(tmp_db):
         project="project_a",   # server is for project_a
     )
     with TestClient(app) as client:
-        # Enqueue impl task belonging to a DIFFERENT project
-        impl = dict(_task_payload("impl-sp21"), context={"project": "project_b"})
+        # Enqueue impl task with top-level project=project_b (different from server's project_a)
+        impl = _task_payload("impl-sp21", project="project_b")
         client.post("/tasks", json=impl)
 
         # Submit result — should NOT auto-enqueue a review task

--- a/tests/unit/test_triage.py
+++ b/tests/unit/test_triage.py
@@ -1,3 +1,8 @@
+import json
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
 from agent_crew.triage import build_prompt, filter_processed, parse_issues, parse_response
 
 
@@ -73,3 +78,101 @@ def test_u_t04b_parse_response_anchored():
 def test_u_t04c_parse_response_missing_fields():
     assert parse_response("just some text with no markers") is None
     assert parse_response("ISSUE: 5\n(no description line)") is None
+
+
+# U-T06: get_project_git_origin — returns git remote URL from project dir
+def test_u_t06_get_project_git_origin(tmp_path):
+    """get_project_git_origin reads the 'origin' remote URL from a git repo."""
+    import subprocess as sp
+    from agent_crew.triage import get_project_git_origin
+
+    # Init a git repo with a remote
+    sp.run(["git", "init"], cwd=str(tmp_path), capture_output=True)
+    sp.run(["git", "remote", "add", "origin", "https://github.com/org/myrepo.git"],
+           cwd=str(tmp_path), capture_output=True)
+
+    url = get_project_git_origin(str(tmp_path))
+    assert url is not None
+    assert "myrepo" in url
+
+
+# U-T07: get_project_git_origin — returns None when no remote configured
+def test_u_t07_get_project_git_origin_no_remote(tmp_path):
+    """Returns None when no 'origin' remote is configured."""
+    import subprocess as sp
+    from agent_crew.triage import get_project_git_origin
+
+    sp.run(["git", "init"], cwd=str(tmp_path), capture_output=True)
+    url = get_project_git_origin(str(tmp_path))
+    assert url is None
+
+
+# U-T08: validate_repo_origin — mismatch gives (False, error_message)
+def test_u_t08_validate_repo_origin_mismatch(tmp_path):
+    """When --repo doesn't match the project's git remote, return (False, msg)
+    with an error message naming both values."""
+    import subprocess as sp
+    from agent_crew.triage import validate_repo_origin
+
+    sp.run(["git", "init"], cwd=str(tmp_path), capture_output=True)
+    sp.run(["git", "remote", "add", "origin", "https://github.com/org/actual-repo.git"],
+           cwd=str(tmp_path), capture_output=True)
+
+    ok, msg = validate_repo_origin("org/other-repo", str(tmp_path))
+    assert ok is False
+    assert "other-repo" in msg or "mismatch" in msg.lower()
+    assert "actual-repo" in msg or "org/other-repo" in msg
+
+
+# U-T09: validate_repo_origin — match gives (True, "")
+def test_u_t09_validate_repo_origin_match(tmp_path):
+    """When --repo matches the project's git remote, return (True, '')."""
+    import subprocess as sp
+    from agent_crew.triage import validate_repo_origin
+
+    sp.run(["git", "init"], cwd=str(tmp_path), capture_output=True)
+    sp.run(["git", "remote", "add", "origin", "https://github.com/org/myrepo.git"],
+           cwd=str(tmp_path), capture_output=True)
+
+    # repo arg can be short form (owner/name) — should match the remote URL
+    ok, msg = validate_repo_origin("org/myrepo", str(tmp_path))
+    assert ok is True
+    assert msg == ""
+
+
+# U-T10: crew triage exits with repo mismatch error when --repo doesn't match project origin
+def test_u_t10_triage_cli_exits_on_repo_mismatch(tmp_path):
+    """crew triage --project X --repo Y must fail immediately with a clear error
+    when Y does not match X's git origin URL. This prevents enqueueing issues
+    from a different repo into the wrong project queue."""
+    from agent_crew.cli import crew
+    from agent_crew.queue import TaskQueue
+
+    db_file = str(tmp_path / "tasks.db")
+    TaskQueue(db_file)
+    state = {
+        "project": "proj_t10",
+        "port": 0,
+        "db": db_file,
+        "session": "crew_proj_t10",
+        "agents": ["claude"],
+        "pane_ids": ["%10"],
+    }
+    (tmp_path / "proj_t10").mkdir()
+    (tmp_path / "proj_t10" / "state.json").write_text(json.dumps(state))
+
+    runner = CliRunner()
+    # validate_repo_origin returns mismatch
+    with patch("agent_crew.triage.validate_repo_origin",
+               return_value=(False, "repo mismatch: --repo org/wrong but project proj_t10 origin is org/actual")):
+        result = runner.invoke(crew, [
+            "triage",
+            "--repo", "org/wrong",
+            "--project", "proj_t10",
+            "--base", str(tmp_path),
+            "--no-confirm",
+        ])
+
+    assert result.exit_code != 0
+    output = result.output.lower()
+    assert "mismatch" in output or "wrong" in output or "repo" in output


### PR DESCRIPTION
## Summary
3개 P0 버그 수정 (#69):

1. **auto-triage repo 라우팅 검증** — `crew triage` 시 `--repo` 인자가 대상 프로젝트 git origin과 일치하는지 검증. 불일치 시 명확한 에러로 종료.
2. **cross-project review 차단** — review 태스크 생성 시 impl 태스크의 project 필드와 일치하는지 가드. 프로젝트 경계 넘는 review 라우팅 거부.
3. **cancel cascade 방지** — 태스크 취소 시 의존 review/test 태스크는 'orphaned'로 마킹만 하고 자동 cancel 안 함. 운영자가 수동 처리.

## Changes
- `src/agent_crew/triage.py` — repo origin 검증 로직
- `src/agent_crew/server.py` — review project 일치 가드
- `src/agent_crew/queue.py` — orphan/requeue API
- `src/agent_crew/protocol.py` — project 필드 typing
- `src/agent_crew/cli.py` — triage 검증 flow
- `tests/unit/test_triage.py` `test_queue.py` `test_server_push.py` — 단위 테스트 +257 lines
- `conftest.py` (root) — pytest sys.path 수정

## Test plan
- [ ] `crew triage --repo wrong/repo --project mine` → 에러 출력 확인
- [ ] impl/review project 불일치 시 review 거부 확인
- [ ] 태스크 cancel 시 dependent task가 orphaned 상태로 남는지 확인
- [ ] `pytest tests/unit/` 통과 확인

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)