### PR TITLE
fix(#74): retry Enter with backoff on rapid task succession

### DIFF
--- a/src/agent_crew/server.py
+++ b/src/agent_crew/server.py
@@ -40,25 +40,38 @@ def _pane_alive_for_push(pane_id: str) -> bool:
 
 
 def _pane_has_task(pane_id: str) -> bool:
-    """Return True if the pane's visible text still contains the task marker.
+    """Return True if pane shows pending input (task marker or collapsed paste).
 
-    When the task is sitting unsubmitted in the composer, the marker is visible.
-    Once Enter is processed the composer clears and the marker disappears.
+    Two signals mean the buffer is still parked in the composer:
+    - ``=== AGENT_CREW TASK ===`` — short pastes render inline, marker visible.
+    - ``[Pasted text`` — Claude Code collapses long pastes; marker is hidden,
+      but the placeholder reveals that input wasn't submitted.
+
+    Once Enter is processed the composer clears and both signals disappear.
     """
     r = subprocess.run(
         ["tmux", "capture-pane", "-p", "-t", pane_id],
         capture_output=True, text=True,
     )
-    return "=== AGENT_CREW TASK ===" in r.stdout
+    out = r.stdout
+    return ("=== AGENT_CREW TASK ===" in out) or ("[Pasted text" in out)
+
+
+# Backoff schedule (seconds) for the per-attempt wait after Enter. The first
+# attempt mirrors the original 0.3s behaviour; subsequent attempts widen so
+# transient post-completion UI states (e.g. "Crunched for…", footer redraws,
+# cache compaction) have time to settle before the next Enter is sent.
+_PUSH_RETRY_DELAYS = (0.3, 0.5, 1.0, 2.0)
 
 
 def _default_push(pane_id: str, text: str) -> None:
-    """Send task via tmux bracketed paste, then retry Enter until task is submitted.
+    """Send task via tmux bracketed paste, then retry Enter until submitted.
 
     Bracketed-paste mode delivers the entire blob atomically. After paste we
-    wait for the TUI to finish consuming it, then send Enter. If the pane still
-    shows the task marker (Enter was dropped or arrived too early), we wait and
-    retry once.
+    wait for the TUI to finish consuming it, then send Enter. Some Claude UI
+    states (post-task footer animations, cache writes between back-to-back
+    tasks — issue #74) drop the first Enter without submitting; we re-send
+    Enter with backoff up to len(_PUSH_RETRY_DELAYS) times.
     """
     logger.debug(f"_default_push called: pane_id={pane_id}")
     task_id = text.split("\n")[1].split(": ")[1] if "task_id:" in text else "unknown"
@@ -81,18 +94,24 @@ def _default_push(pane_id: str, text: str) -> None:
     # Give the TUI time to process the bracketed-paste sequence.
     time.sleep(0.5)
 
-    r3 = subprocess.run(["tmux", "send-keys", "-t", pane_id, "Enter"], capture_output=True)
-    logger.debug(f"send-keys Enter result: rc={r3.returncode}, stderr={r3.stderr[:100] if r3.stderr else 'ok'}")
+    for attempt, wait_after in enumerate(_PUSH_RETRY_DELAYS, start=1):
+        subprocess.run(["tmux", "send-keys", "-t", pane_id, "Enter"], capture_output=True)
+        time.sleep(wait_after)
+        if not _pane_has_task(pane_id):
+            logger.info(
+                f"PUSH SUCCESS: task_id={task_id} pushed to {pane_id} "
+                f"(attempt {attempt}/{len(_PUSH_RETRY_DELAYS)})"
+            )
+            return
+        logger.warning(
+            f"PUSH retry: attempt {attempt}/{len(_PUSH_RETRY_DELAYS)} for "
+            f"task_id={task_id} — composer still holding input"
+        )
 
-    # Verify delivery: if task marker still visible the Enter was dropped — retry once.
-    time.sleep(0.3)
-    if _pane_has_task(pane_id):
-        logger.warning(f"PUSH: task marker still visible, retrying Enter for {task_id}")
-        time.sleep(0.2)
-        r4 = subprocess.run(["tmux", "send-keys", "-t", pane_id, "Enter"], capture_output=True)
-        logger.debug(f"send-keys Enter retry result: rc={r4.returncode}")
-    else:
-        logger.info(f"PUSH SUCCESS: task_id={task_id} pushed to {pane_id}")
+    logger.error(
+        f"PUSH FAILED: task_id={task_id} still pending after "
+        f"{len(_PUSH_RETRY_DELAYS)} Enter attempts on {pane_id}"
+    )
 
 
 def _format_task_message(task: TaskRequest, port: int) -> str:

--- a/tests/unit/test_server_push.py
+++ b/tests/unit/test_server_push.py
@@ -324,6 +324,81 @@ def test_u_sp13_default_push_uses_bracketed_paste(monkeypatch):
     assert "capture-pane" in capture_args
 
 
+# U-SP13b: _pane_has_task detects collapsed `[Pasted text` placeholder so a
+# stuck large paste isn't mistaken for a successfully submitted task.
+# Background: Claude Code collapses long pastes into `[Pasted text #N +X lines]`,
+# so the raw `=== AGENT_CREW TASK ===` marker isn't visible — the previous
+# detection logic returned False (false positive of success).
+def test_u_sp13b_pane_has_task_detects_collapsed_paste(monkeypatch):
+    from unittest.mock import MagicMock
+    from agent_crew.server import _pane_has_task
+
+    mock_run = MagicMock(return_value=MagicMock(
+        returncode=0,
+        stdout="❯ [Pasted text #2 +42 lines]\n",
+    ))
+    monkeypatch.setattr("agent_crew.server.subprocess.run", mock_run)
+
+    assert _pane_has_task("%42") is True
+
+
+# U-SP13c: _default_push retries Enter with backoff when the marker stays
+# visible — covers the rapid-task-succession race where the first Enter is
+# consumed by Claude's post-completion UI transition (issue #74).
+def test_u_sp13c_default_push_retries_with_backoff(monkeypatch):
+    from unittest.mock import MagicMock
+    from agent_crew.server import _default_push
+
+    # Simulate marker visible for the first 2 capture-pane calls, gone on the
+    # 3rd. Each iteration: send-keys Enter + capture-pane (2 subprocess calls).
+    captures = [
+        MagicMock(returncode=0, stdout="=== AGENT_CREW TASK ==="),  # 1st check
+        MagicMock(returncode=0, stdout="=== AGENT_CREW TASK ==="),  # 2nd check
+        MagicMock(returncode=0, stdout=""),                          # 3rd check (clear)
+    ]
+    capture_iter = iter(captures)
+
+    def fake_run(cmd, *args, **kwargs):
+        if "capture-pane" in cmd:
+            return next(capture_iter)
+        return MagicMock(returncode=0, stdout="", stderr=b"")
+
+    sleeps: list[float] = []
+    monkeypatch.setattr("agent_crew.server.subprocess.run", fake_run)
+    monkeypatch.setattr("agent_crew.server.time.sleep", lambda s: sleeps.append(s))
+
+    _default_push("%42", "=== AGENT_CREW TASK ===\ntask_id: t-074\nbody")
+
+    # Expected sequence: paste-settle sleep, then per-attempt (send Enter, sleep,
+    # capture-pane). 3 attempts to reach success, so 3 post-Enter sleeps.
+    # Total sleeps = 1 (paste settle) + 3 (per attempt) = 4.
+    assert len(sleeps) == 4
+    # Backoff increases monotonically across attempts.
+    assert sleeps[1] < sleeps[2] < sleeps[3]
+
+
+# U-SP13d: _default_push gives up after the configured max attempts and logs
+# an error — keeps the server from spinning forever on a wedged pane.
+def test_u_sp13d_default_push_gives_up_after_max_attempts(monkeypatch, caplog):
+    import logging
+    from unittest.mock import MagicMock
+    from agent_crew.server import _default_push
+
+    # Marker stays visible forever — every capture-pane returns it.
+    def fake_run(cmd, *args, **kwargs):
+        if "capture-pane" in cmd:
+            return MagicMock(returncode=0, stdout="=== AGENT_CREW TASK ===")
+        return MagicMock(returncode=0, stdout="", stderr=b"")
+
+    monkeypatch.setattr("agent_crew.server.subprocess.run", fake_run)
+    monkeypatch.setattr("agent_crew.server.time.sleep", lambda _: None)
+
+    with caplog.at_level(logging.ERROR, logger="agent_crew.server"):
+        _default_push("%42", "=== AGENT_CREW TASK ===\ntask_id: t-074\nbody")
+
+    assert any("PUSH FAILED" in rec.message for rec in caplog.records)
+
+
 # U-SP14: impl task completed → auto-enqueue review task
 def test_u_sp14_impl_completed_auto_enqueue_review(tmp_db):
     push = RecordingPush()


### PR DESCRIPTION
## Summary

Fixes #74. When `crew discuss` pushed tasks in rapid succession, Claude's post-completion UI consumed the first Enter without submitting, leaving the paste parked in the composer and the task stuck.

- `_pane_has_task` now also detects `[Pasted text` — Claude collapses long pastes into a placeholder, hiding the `AGENT_CREW` marker, so the previous check returned a false success on stuck panes.
- `_default_push` retries Enter up to 4 times with backoff (0.3s → 0.5s → 1.0s → 2.0s) and logs `PUSH FAILED` if the composer never clears.

The original logic was a single retry with a 0.2s delay, which wasn't enough time for transient post-task UI states (footer animations, cache writes) to settle.

## Out of scope

The secondary symptom in #74 — "result not submitted after manual trigger" — is purely Claude-side behavior and can't be fixed from the framework. The MANDATORY POST language already exists in `instructions.py`. A heartbeat / re-push watchdog could address it but is a larger change for a separate issue.

## Test plan

- [x] `pytest tests/unit/test_server_push.py` — 24 passed (4 new: U-SP13b/c/d cover collapsed-paste detection, retry-with-backoff, and give-up-after-max)
- [x] `pytest tests/unit/` — 165 passed, 3 pre-existing failures on `test_cli.py::test_u_c20/21/22` (unrelated to this change, present on origin/main)
- [x] `ruff check` — no new errors (5 pre-existing errors in untouched code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)