### PR TITLE
fix(#76): add heartbeat watchdog (reminder + timeout) for stuck tasks

### DIFF
--- a/src/agent_crew/queue.py
+++ b/src/agent_crew/queue.py
@@ -35,23 +35,27 @@ CREATE TABLE IF NOT EXISTS gates (
 
 _DDL = """
 CREATE TABLE IF NOT EXISTS tasks (
-    task_id     TEXT PRIMARY KEY,
-    task_type   TEXT NOT NULL,
-    description TEXT NOT NULL,
-    branch      TEXT NOT NULL DEFAULT '',
-    priority    INTEGER NOT NULL DEFAULT 3,
-    context     TEXT NOT NULL DEFAULT '{}',
-    status      TEXT NOT NULL DEFAULT 'pending',
-    created_at  REAL NOT NULL,
-    project     TEXT NOT NULL DEFAULT '',
-    summary     TEXT,
-    verdict     TEXT,
-    findings    TEXT,
-    pr_number   INTEGER
+    task_id          TEXT PRIMARY KEY,
+    task_type        TEXT NOT NULL,
+    description      TEXT NOT NULL,
+    branch           TEXT NOT NULL DEFAULT '',
+    priority         INTEGER NOT NULL DEFAULT 3,
+    context          TEXT NOT NULL DEFAULT '{}',
+    status           TEXT NOT NULL DEFAULT 'pending',
+    created_at       REAL NOT NULL,
+    project          TEXT NOT NULL DEFAULT '',
+    summary          TEXT,
+    verdict          TEXT,
+    findings         TEXT,
+    pr_number        INTEGER,
+    last_activity_at REAL NOT NULL DEFAULT 0
 )
 """
 
 _DDL_MIGRATE_PROJECT = "ALTER TABLE tasks ADD COLUMN project TEXT NOT NULL DEFAULT ''"
+_DDL_MIGRATE_LAST_ACTIVITY = (
+    "ALTER TABLE tasks ADD COLUMN last_activity_at REAL NOT NULL DEFAULT 0"
+)
 
 _DDL_CHECKPOINTS = """
 CREATE TABLE IF NOT EXISTS checkpoints (
@@ -86,6 +90,10 @@ class TaskQueue:
         # Migrate existing DBs: add project column if absent
         try:
             conn.execute(_DDL_MIGRATE_PROJECT)
+        except Exception:
+            pass  # column already exists
+        try:
+            conn.execute(_DDL_MIGRATE_LAST_ACTIVITY)
         except Exception:
             pass  # column already exists
         # Create indexes for performance
@@ -157,8 +165,8 @@ class TaskQueue:
                 return None
 
             conn.execute(
-                "UPDATE tasks SET status = 'in_progress' WHERE task_id = ?",
-                (row["task_id"],),
+                "UPDATE tasks SET status = 'in_progress', last_activity_at = ? WHERE task_id = ?",
+                (time.time(), row["task_id"]),
             )
             conn.execute("COMMIT")
 
@@ -325,8 +333,8 @@ class TaskQueue:
                 conn.execute("ROLLBACK")
                 return None
             conn.execute(
-                "UPDATE tasks SET status = 'in_progress' WHERE task_id = ?",
-                (chosen["task_id"],),
+                "UPDATE tasks SET status = 'in_progress', last_activity_at = ? WHERE task_id = ?",
+                (time.time(), chosen["task_id"]),
             )
             conn.execute("COMMIT")
             return TaskRequest(
@@ -543,6 +551,74 @@ class TaskQueue:
             if row is None:
                 return None
             return (row["checkpoint_num"], json.loads(row["state_snapshot"]))
+        finally:
+            conn.close()
+
+    def bump_activity(self, task_id: str, ts: Optional[float] = None) -> None:
+        """Refresh last_activity_at for a task. Called by the watchdog whenever
+        the agent's pane is observed busy, so the timeout/reminder clocks
+        restart from the most recent sign of life."""
+        if ts is None:
+            ts = time.time()
+        conn = self._connect()
+        try:
+            conn.execute(
+                "UPDATE tasks SET last_activity_at = ? WHERE task_id = ? AND status = 'in_progress'",
+                (ts, task_id),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def list_in_progress_with_activity(self) -> List[dict]:
+        """Return dicts with the fields the watchdog needs to make timeout
+        decisions: task_id, task_type, context, last_activity_at, project."""
+        conn = self._connect()
+        try:
+            rows = conn.execute(
+                "SELECT task_id, task_type, context, last_activity_at, project "
+                "FROM tasks WHERE status = 'in_progress'"
+            ).fetchall()
+            return [
+                {
+                    "task_id": r["task_id"],
+                    "task_type": r["task_type"],
+                    "context": json.loads(r["context"]) if r["context"] else {},
+                    "last_activity_at": r["last_activity_at"] or 0.0,
+                    "project": r["project"] if r["project"] else "",
+                }
+                for r in rows
+            ]
+        finally:
+            conn.close()
+
+    def force_fail(self, task_id: str, summary: str) -> Optional[str]:
+        """Mark an in_progress task as failed (used by the watchdog when a pane
+        has been silent past the timeout). Returns the task_type so callers can
+        push the next task to the now-idle role, or None if the row wasn't
+        in_progress (e.g. result arrived just before the watchdog tick)."""
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            row = conn.execute(
+                "SELECT task_type, status FROM tasks WHERE task_id = ?",
+                (task_id,),
+            ).fetchone()
+            if row is None or row["status"] != "in_progress":
+                conn.execute("ROLLBACK")
+                return None
+            conn.execute(
+                "UPDATE tasks SET status = 'failed', summary = ? WHERE task_id = ?",
+                (summary, task_id),
+            )
+            conn.execute("COMMIT")
+            return row["task_type"]
+        except Exception:
+            try:
+                conn.execute("ROLLBACK")
+            except Exception:
+                pass
+            raise
         finally:
             conn.close()
 

--- a/src/agent_crew/server.py
+++ b/src/agent_crew/server.py
@@ -1,3 +1,5 @@
+import asyncio
+import contextlib
 import json
 import logging
 import os
@@ -37,6 +39,36 @@ def _pane_alive_for_push(pane_id: str) -> bool:
         capture_output=True,
     )
     return r.returncode == 0
+
+
+def _pane_is_busy(pane_id: str) -> bool:
+    """Return True if the pane shows the agent is actively processing.
+
+    Looks for indicators that the underlying CLI (Claude Code, codex, gemini)
+    is mid-thought:
+    - ``esc to interrupt`` — Claude/Codex footer while a tool/agent is running
+    - ``Crunched`` / ``Compacting`` — Claude active state lines
+    - ``Working`` / ``Thinking`` — alternate active states
+    - ``✻`` / ``✽`` — Claude spinner glyph
+
+    A False return means the pane is sitting idle (prompt visible, no spinner).
+    Used by the watchdog to decide whether to bump last_activity_at.
+    """
+    r = subprocess.run(
+        ["tmux", "capture-pane", "-p", "-t", pane_id],
+        capture_output=True, text=True,
+    )
+    out = r.stdout
+    busy_markers = (
+        "esc to interrupt",
+        "Crunched",
+        "Compacting",
+        "Working",
+        "Thinking",
+        "✻",
+        "✽",
+    )
+    return any(marker in out for marker in busy_markers)
 
 
 def _pane_has_task(pane_id: str) -> bool:
@@ -95,6 +127,30 @@ def _default_push(pane_id: str, text: str) -> None:
         logger.info(f"PUSH SUCCESS: task_id={task_id} pushed to {pane_id}")
 
 
+def _format_reminder_message(task_id: str, port: int, idle_seconds: float) -> str:
+    """Watchdog nudge: agent has been silent past the heartbeat threshold.
+
+    Includes the canonical POST template so the agent can resolve the task in
+    one paste even if the original block scrolled out of context.
+    """
+    return (
+        f"=== AGENT_CREW REMINDER ===\n"
+        f"task_id: {task_id}\n"
+        f"Your assigned task has been silent for {idle_seconds:.0f}s with no\n"
+        f"sign of activity in this pane. The crew stalls until you POST the\n"
+        f"result.\n"
+        f"\n"
+        f"If finished, POST now:\n"
+        f"  curl -sS -X POST http://127.0.0.1:{port}/tasks/{task_id}/result \\\n"
+        f"    -H 'Content-Type: application/json' \\\n"
+        f"    -d '{{\"task_id\":\"{task_id}\",\"status\":\"completed\","
+        f"\"summary\":\"...\",\"verdict\":null,\"findings\":[],\"pr_number\":null}}'\n"
+        f"\n"
+        f"If still working, ignore this — the next heartbeat will see you busy.\n"
+        f"=== END REMINDER ===\n"
+    )
+
+
 def _format_task_message(task: TaskRequest, port: int) -> str:
     ctx = json.dumps(task.context, ensure_ascii=False)
     return (
@@ -119,6 +175,11 @@ def create_app(
     port: int = 0,
     push_fn: Callable[[str, str], None] = _default_push,
     project: Optional[str] = None,
+    pane_busy_fn: Callable[[str], bool] = _pane_is_busy,
+    watchdog_interval: Optional[float] = None,
+    reminder_seconds: Optional[float] = None,
+    timeout_seconds: Optional[float] = None,
+    watchdog_disabled: Optional[bool] = None,
 ) -> FastAPI:
     """
     pane_map: {role: pane_id} — e.g. {"implementer": "%475"}. If None, push is disabled.
@@ -126,18 +187,53 @@ def create_app(
     agents know where to POST results). Defaults to 0 (messages will say port 0).
     push_fn: injectable for testing.
     project: optional project name used to guard against cross-project review routing.
+    pane_busy_fn: injectable pane-state probe for the watchdog. Defaults to
+        ``_pane_is_busy`` (tmux capture-pane based).
+    watchdog_interval: seconds between watchdog ticks. Falls back to env
+        ``AGENT_CREW_WATCHDOG_INTERVAL`` then 30s.
+    reminder_seconds: idle threshold (seconds) before pushing a reminder.
+        Falls back to env ``AGENT_CREW_REMINDER_SECONDS`` then 300s.
+    timeout_seconds: idle threshold (seconds) before auto-failing the task.
+        Falls back to env ``AGENT_CREW_TIMEOUT_SECONDS`` then 900s.
+    watchdog_disabled: skip the background loop entirely (tests). Falls back
+        to env ``AGENT_CREW_WATCHDOG_DISABLED``.
     """
+    if watchdog_interval is None:
+        watchdog_interval = float(os.getenv("AGENT_CREW_WATCHDOG_INTERVAL", "30"))
+    if reminder_seconds is None:
+        reminder_seconds = float(os.getenv("AGENT_CREW_REMINDER_SECONDS", "300"))
+    if timeout_seconds is None:
+        timeout_seconds = float(os.getenv("AGENT_CREW_TIMEOUT_SECONDS", "900"))
+    if watchdog_disabled is None:
+        watchdog_disabled = os.getenv("AGENT_CREW_WATCHDOG_DISABLED", "").lower() in (
+            "1", "true", "yes",
+        )
+
     state: dict = {}
+    reminded_task_ids: set[str] = set()
 
     @asynccontextmanager
     async def lifespan(app: FastAPI):
         state["queue"] = TaskQueue(db_path)
-        yield
+        watchdog_task = None
+        if not watchdog_disabled:
+            watchdog_task = asyncio.create_task(_watchdog_loop())
+        try:
+            yield
+        finally:
+            if watchdog_task is not None:
+                watchdog_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError, Exception):
+                    await watchdog_task
 
     app = FastAPI(lifespan=lifespan)
 
     def q() -> TaskQueue:
         return state["queue"]
+
+    # Expose watchdog tick on app.state so tests can drive it deterministically
+    # without the asyncio loop. Production code never reads this attribute.
+    app.state.reminded_task_ids = reminded_task_ids
 
     def _try_push_next(role: str) -> None:
         """If the role has an available pane and is idle, dequeue and push the next task."""
@@ -217,6 +313,109 @@ def create_app(
 
         logger.info(f"_try_push_discuss: dequeued task_id={task.task_id} for agent={agent}, calling push_fn")
         push_fn(pane_id, _format_task_message(task, port))
+
+    def _resolve_pane_for_row(row: dict) -> Optional[str]:
+        """Find the pane assigned to an in_progress task row. Mirrors the routing
+        used by _try_push_next / _try_push_discuss so the watchdog inspects
+        the same pane that received the task."""
+        if not pane_map:
+            return None
+        ctx = row.get("context") or {}
+        task_type = row["task_type"]
+        if task_type == "discuss":
+            agent = ctx.get("agent") if isinstance(ctx, dict) else None
+            return pane_map.get(agent) if agent else None
+        if isinstance(ctx, dict) and ctx.get("agent_override"):
+            return pane_map.get(ctx["agent_override"])
+        role = _TYPE_TO_ROLE.get(task_type)
+        return pane_map.get(role) if role else None
+
+    def _watchdog_tick(now: float) -> dict:
+        """One pass of the heartbeat watchdog. Returns a summary of actions for
+        observability and tests:
+
+        - ``bumped``  — task_ids whose last_activity_at we refreshed
+        - ``reminded`` — task_ids that received a nudge for the first time
+        - ``timed_out`` — task_ids that we auto-failed
+        """
+        actions: dict = {"bumped": [], "reminded": [], "timed_out": []}
+        if not pane_map:
+            return actions
+
+        rows = q().list_in_progress_with_activity()
+        in_progress_ids = {r["task_id"] for r in rows}
+        # Drop completed/failed tasks from the reminder dedupe set so a recycled
+        # task_id (or a re-enqueued retry) doesn't get its reminder suppressed.
+        reminded_task_ids.intersection_update(in_progress_ids)
+
+        for row in rows:
+            task_id = row["task_id"]
+            pane_id = _resolve_pane_for_row(row)
+            if not pane_id:
+                continue
+            try:
+                if pane_busy_fn(pane_id):
+                    q().bump_activity(task_id, ts=now)
+                    actions["bumped"].append(task_id)
+                    # Busy pane resets the reminder cycle — agent is alive.
+                    reminded_task_ids.discard(task_id)
+                    continue
+            except Exception:
+                logger.exception(f"watchdog: pane_busy_fn raised for {pane_id}")
+                continue
+
+            idle_for = now - (row["last_activity_at"] or now)
+            if idle_for >= timeout_seconds:
+                summary = (
+                    f"watchdog timeout: pane idle {idle_for:.0f}s without "
+                    f"sign of activity (threshold {timeout_seconds:.0f}s)"
+                )
+                tt = q().force_fail(task_id, summary)
+                logger.error(
+                    f"WATCHDOG TIMEOUT: task_id={task_id} marked failed; "
+                    f"task_type={tt}, idle_for={idle_for:.0f}s"
+                )
+                reminded_task_ids.discard(task_id)
+                actions["timed_out"].append(task_id)
+                if tt is not None:
+                    role = _TYPE_TO_ROLE.get(tt)
+                    if role:
+                        try:
+                            _try_push_next(role)
+                        except Exception:
+                            logger.exception(
+                                f"watchdog: failed to push next task for role {role}"
+                            )
+            elif idle_for >= reminder_seconds and task_id not in reminded_task_ids:
+                try:
+                    push_fn(pane_id, _format_reminder_message(task_id, port, idle_for))
+                except Exception:
+                    logger.exception(
+                        f"watchdog: failed to push reminder for {task_id}"
+                    )
+                else:
+                    reminded_task_ids.add(task_id)
+                    actions["reminded"].append(task_id)
+                    logger.warning(
+                        f"WATCHDOG REMINDER: task_id={task_id} idle for "
+                        f"{idle_for:.0f}s — nudged pane {pane_id}"
+                    )
+        return actions
+
+    # Stash the tick for tests; harmless in production (never read by handlers).
+    app.state.watchdog_tick = _watchdog_tick
+
+    async def _watchdog_loop() -> None:
+        """Periodic background sweep. Cancels cleanly on shutdown."""
+        try:
+            while True:
+                await asyncio.sleep(watchdog_interval)
+                try:
+                    _watchdog_tick(time.time())
+                except Exception:
+                    logger.exception("watchdog tick raised — continuing")
+        except asyncio.CancelledError:
+            return
 
     def _auto_enqueue_review(impl_task_id: str) -> None:
         """Auto-enqueue a review task when an impl task completes.

--- a/tests/unit/test_server_watchdog.py
+++ b/tests/unit/test_server_watchdog.py
@@ -1,0 +1,269 @@
+"""Unit tests for the heartbeat / inactivity watchdog (issue #76).
+
+The watchdog runs as a background asyncio task in production. These tests
+drive the synchronous tick directly via ``app.state.watchdog_tick`` so we
+don't have to deal with timing.
+"""
+from fastapi.testclient import TestClient
+
+from agent_crew.queue import TaskQueue
+from agent_crew.server import create_app
+
+
+def _task_payload(task_id="t1", task_type="implement", description="do work", priority=3, project=""):
+    return {
+        "task_id": task_id,
+        "task_type": task_type,
+        "description": description,
+        "branch": "main",
+        "priority": priority,
+        "context": {},
+        "project": project,
+    }
+
+
+def _result_payload(task_id, status="completed", summary="done"):
+    return {
+        "task_id": task_id,
+        "status": status,
+        "summary": summary,
+        "verdict": None,
+        "findings": [],
+        "pr_number": None,
+    }
+
+
+class _PaneState:
+    """Toggleable pane busy/idle state keyed by pane_id."""
+
+    def __init__(self):
+        self.busy: dict[str, bool] = {}
+
+    def set_busy(self, pane_id: str, busy: bool) -> None:
+        self.busy[pane_id] = busy
+
+    def __call__(self, pane_id: str) -> bool:
+        return self.busy.get(pane_id, False)
+
+
+class _RecordingPush:
+    def __init__(self):
+        self.calls: list[tuple[str, str]] = []
+
+    def __call__(self, pane_id: str, text: str) -> None:
+        self.calls.append((pane_id, text))
+
+
+def _make_app(tmp_db, *, panes, busy_fn, push_fn,
+              reminder=300.0, timeout=900.0):
+    return create_app(
+        db_path=tmp_db,
+        pane_map=panes,
+        port=8100,
+        push_fn=push_fn,
+        pane_busy_fn=busy_fn,
+        reminder_seconds=reminder,
+        timeout_seconds=timeout,
+        watchdog_disabled=True,  # we drive ticks manually
+    )
+
+
+# U-WD01: Busy pane → last_activity_at refreshed, no reminder/timeout fired.
+def test_u_wd01_busy_pane_bumps_activity(tmp_db):
+    busy = _PaneState()
+    push = _RecordingPush()
+    app = _make_app(tmp_db, panes={"implementer": "%100"}, busy_fn=busy, push_fn=push)
+
+    with TestClient(app) as client:
+        client.post("/tasks", json=_task_payload("t-busy"))
+        # First push fires synchronously on enqueue → 1 push call so far.
+        assert len(push.calls) == 1
+
+        # Pane is busy → tick should bump activity, NOT send reminder/timeout.
+        busy.set_busy("%100", True)
+        # Run the tick well past both thresholds — busy state must short-circuit.
+        result = app.state.watchdog_tick(now=10_000.0)
+
+    assert result["bumped"] == ["t-busy"]
+    assert result["reminded"] == []
+    assert result["timed_out"] == []
+    # Activity row updated to "now" so a subsequent idle tick starts the clock fresh.
+    rows = TaskQueue(tmp_db).list_in_progress_with_activity()
+    assert rows and rows[0]["last_activity_at"] == 10_000.0
+    # No extra push (no reminder).
+    assert len(push.calls) == 1
+
+
+# U-WD02: Idle pane below the reminder threshold → no action.
+def test_u_wd02_idle_within_threshold_noop(tmp_db):
+    busy = _PaneState()
+    push = _RecordingPush()
+    app = _make_app(tmp_db, panes={"implementer": "%100"},
+                    busy_fn=busy, push_fn=push,
+                    reminder=300.0, timeout=900.0)
+
+    with TestClient(app) as client:
+        client.post("/tasks", json=_task_payload("t-young"))
+        # Force a known last_activity_at so we control idle_for precisely.
+        TaskQueue(tmp_db).bump_activity("t-young", ts=1000.0)
+
+        # 100s elapsed (< reminder 300s) → no reminder/timeout.
+        result = app.state.watchdog_tick(now=1100.0)
+
+    assert result == {"bumped": [], "reminded": [], "timed_out": []}
+    # Only the original task push is recorded — no nudge.
+    assert len(push.calls) == 1
+
+
+# U-WD03: Idle ≥ reminder threshold → exactly one nudge pushed; subsequent
+# ticks at the same idle level don't spam.
+def test_u_wd03_idle_past_reminder_pushes_once(tmp_db):
+    busy = _PaneState()
+    push = _RecordingPush()
+    app = _make_app(tmp_db, panes={"implementer": "%100"},
+                    busy_fn=busy, push_fn=push,
+                    reminder=300.0, timeout=900.0)
+
+    with TestClient(app) as client:
+        client.post("/tasks", json=_task_payload("t-idle"))
+        TaskQueue(tmp_db).bump_activity("t-idle", ts=1000.0)
+        # idle_for = 400s — past reminder, well under timeout.
+        first = app.state.watchdog_tick(now=1400.0)
+        second = app.state.watchdog_tick(now=1500.0)
+
+    assert first["reminded"] == ["t-idle"]
+    assert second["reminded"] == []
+    # Reminder push counted — original + 1 nudge = 2 calls.
+    assert len(push.calls) == 2
+    nudge_text = push.calls[1][1]
+    assert "AGENT_CREW REMINDER" in nudge_text
+    assert "t-idle" in nudge_text
+
+
+# U-WD04: A busy heartbeat between two idle ticks resets the dedupe set, so
+# the next idle stretch can earn a fresh reminder.
+def test_u_wd04_reminder_dedupe_resets_after_busy(tmp_db):
+    busy = _PaneState()
+    push = _RecordingPush()
+    app = _make_app(tmp_db, panes={"implementer": "%100"},
+                    busy_fn=busy, push_fn=push,
+                    reminder=300.0, timeout=10_000.0)
+
+    with TestClient(app) as client:
+        client.post("/tasks", json=_task_payload("t-flap"))
+        TaskQueue(tmp_db).bump_activity("t-flap", ts=1000.0)
+
+        app.state.watchdog_tick(now=1400.0)  # idle 400s → reminder fires
+        busy.set_busy("%100", True)
+        app.state.watchdog_tick(now=1500.0)  # busy → bump, drop from dedupe
+        busy.set_busy("%100", False)
+        # Activity is now 1500.0 → idle_for = 1900-1500 = 400s past reminder again.
+        result = app.state.watchdog_tick(now=1900.0)
+
+    assert result["reminded"] == ["t-flap"]
+    # 2 reminders total + 1 original push = 3.
+    assert len(push.calls) == 3
+
+
+# U-WD05: Idle ≥ timeout → task auto-failed, role released, queued task pushed.
+def test_u_wd05_idle_past_timeout_auto_fails_and_pushes_next(tmp_db):
+    busy = _PaneState()
+    push = _RecordingPush()
+    app = _make_app(tmp_db, panes={"implementer": "%100"},
+                    busy_fn=busy, push_fn=push,
+                    reminder=300.0, timeout=900.0)
+
+    with TestClient(app) as client:
+        # First task — pushed immediately, marked in_progress.
+        client.post("/tasks", json=_task_payload("t-stuck"))
+        # Second task — queued behind t-stuck because impl role is busy.
+        client.post("/tasks", json=_task_payload("t-next"))
+        assert len(push.calls) == 1, "second task should have been queued"
+
+        TaskQueue(tmp_db).bump_activity("t-stuck", ts=1000.0)
+        # idle_for = 1500s → past timeout (900s).
+        result = app.state.watchdog_tick(now=2500.0)
+
+    assert result["timed_out"] == ["t-stuck"]
+    # Stuck task should now be 'failed' in the DB. list_tasks returns
+    # TaskRequests without status, so verify via list_all_with_status.
+    all_with_status = TaskQueue(tmp_db).list_all_with_status()
+    stuck_status = next(r["status"] for r in all_with_status if r["task_id"] == "t-stuck")
+    assert stuck_status == "failed"
+    # Next queued task pushed to the now-idle implementer pane.
+    assert len(push.calls) == 2
+    assert "t-next" in push.calls[1][1]
+
+
+# U-WD06: discuss tasks → watchdog uses context.agent for pane resolution.
+def test_u_wd06_resolves_discuss_pane_via_agent(tmp_db):
+    busy = _PaneState()
+    push = _RecordingPush()
+    panes = {"panel": "%999", "claude": "%CLA", "codex": "%COD"}
+    app = _make_app(tmp_db, panes=panes, busy_fn=busy, push_fn=push,
+                    reminder=300.0, timeout=900.0)
+
+    with TestClient(app) as client:
+        payload = _task_payload("d-claude", task_type="discuss",
+                                description="Topic X")
+        payload["context"] = {"agent": "claude"}
+        client.post("/tasks", json=payload)
+        TaskQueue(tmp_db).bump_activity("d-claude", ts=1000.0)
+        # Mark only the *correct* pane busy — if resolution were broken the
+        # watchdog would treat this task as idle.
+        busy.set_busy("%CLA", True)
+        result = app.state.watchdog_tick(now=1500.0)
+
+    assert result["bumped"] == ["d-claude"]
+
+
+# U-WD06b: Background loop actually fires ticks while the app is alive and
+# cancels cleanly on shutdown — covers the asyncio plumbing the unit-tick
+# tests skip via watchdog_disabled=True.
+def test_u_wd06b_async_loop_runs_and_cancels(tmp_db):
+    busy = _PaneState()
+    push = _RecordingPush()
+    app = create_app(
+        db_path=tmp_db,
+        pane_map={"implementer": "%100"},
+        port=8100,
+        push_fn=push,
+        pane_busy_fn=busy,
+        reminder_seconds=300.0,
+        timeout_seconds=10_000.0,
+        watchdog_interval=0.05,   # tight loop so the test is quick
+        watchdog_disabled=False,
+    )
+    import time as _t
+
+    with TestClient(app) as client:
+        client.post("/tasks", json=_task_payload("t-loop"))
+        TaskQueue(tmp_db).bump_activity("t-loop", ts=_t.time() - 1000.0)
+        busy.set_busy("%100", True)
+        # Give the loop a couple of ticks to bump activity.
+        _t.sleep(0.25)
+    # If we reach here without hanging, lifespan cancelled the loop on exit.
+    rows = TaskQueue(tmp_db).list_in_progress_with_activity()
+    assert rows
+    assert rows[0]["last_activity_at"] >= _t.time() - 5.0
+
+
+# U-WD07: pane_busy_fn raising must not crash the tick — broken pane probes
+# shouldn't take down the whole server.
+def test_u_wd07_pane_busy_fn_exception_swallowed(tmp_db):
+    push = _RecordingPush()
+
+    def angry_busy_fn(_pane_id: str) -> bool:
+        raise RuntimeError("tmux exploded")
+
+    app = _make_app(tmp_db, panes={"implementer": "%100"},
+                    busy_fn=angry_busy_fn, push_fn=push,
+                    reminder=300.0, timeout=900.0)
+
+    with TestClient(app) as client:
+        client.post("/tasks", json=_task_payload("t-err"))
+        TaskQueue(tmp_db).bump_activity("t-err", ts=1000.0)
+        # Should return cleanly; nothing bumped/reminded/timed_out for this task.
+        result = app.state.watchdog_tick(now=2500.0)
+
+    assert result == {"bumped": [], "reminded": [], "timed_out": []}


### PR DESCRIPTION
## Summary

Closes #76. Implements **A + B** from the issue: a server-side heartbeat watchdog that nudges silent agents and auto-fails tasks whose panes have been idle past a configurable timeout. This unblocks the queue when an agent finishes work but skips the mandatory result POST.

## How it works

A FastAPI lifespan task wakes every `AGENT_CREW_WATCHDOG_INTERVAL` seconds and inspects every `in_progress` task:

| Pane state | Idle for | Action |
|---|---|---|
| Busy (`esc to interrupt`, `Crunched`, `✻`, etc.) | — | refresh `last_activity_at`; reset reminder dedupe |
| Idle | < `REMINDER_SECONDS` | no action |
| Idle | ≥ `REMINDER_SECONDS` | push one reminder block with the canonical POST curl (deduped) |
| Idle | ≥ `TIMEOUT_SECONDS` | `force_fail` task, release role, push next queued task |

Reminder pushes reuse the existing `push_fn`, so dead-pane and paste-retry safeguards still apply. The dedupe set tracks task_ids that already got a nudge so they aren't spammed; a busy heartbeat clears the entry so a re-stalled agent can earn a fresh reminder later.

## Schema changes

- `tasks.last_activity_at REAL NOT NULL DEFAULT 0` — bumped on dequeue and by the watchdog. Existing DBs get an `ALTER TABLE … ADD COLUMN` migration alongside the existing `project` migration.
- New `TaskQueue` helpers: `bump_activity`, `list_in_progress_with_activity`, `force_fail`.

## New env knobs

| Variable | Default | Purpose |
|---|---|---|
| `AGENT_CREW_WATCHDOG_INTERVAL` | 30s | seconds between watchdog ticks |
| `AGENT_CREW_REMINDER_SECONDS` | 300s | idle threshold for the nudge |
| `AGENT_CREW_TIMEOUT_SECONDS` | 900s | idle threshold for auto-fail |
| `AGENT_CREW_WATCHDOG_DISABLED` | unset | set to `1` / `true` / `yes` to opt out |

All four are also exposed as `create_app` kwargs for tests.

## Test plan

- [x] `pytest tests/unit/test_server_watchdog.py` — 8 new tests pass (busy bump, sub-threshold noop, single-fire reminder, dedupe-resets-after-busy, timeout auto-fail-and-push-next, discuss agent routing, async lifespan loop start/cancel, exception isolation)
- [x] `pytest tests/unit/` — 170 passed, 3 pre-existing failures on `test_cli.py::test_u_c20/21/22` (also fail on origin/main, unrelated to this change)
- [x] `ruff check` — no new errors (3 pre-existing errors in untouched code)
- [x] Manual: `create_app(..., watchdog_disabled=True)` short-circuits the loop; default path schedules + cancels the task cleanly via the lifespan context manager.

## Out of scope (still possible follow-ups for #76 alternatives)

- **C** (stronger task-message footer) — the existing `instructions.py` MANDATORY language stays as is; the reminder block now reinforces it on demand.
- **D** (`crew tasks retry-stuck` CLI) — could land later as a manual escape hatch alongside the automated watchdog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)