### PR TITLE
docs: unify runtime paths to ~/.agent_crew

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -37,8 +37,8 @@
 ### 2.1 Task Queue + Gate Server
 
 - **Runtime**: FastAPI + uvicorn, runs as a background process
-- **Port**: auto-selected starting from 8100; written to `/tmp/agent_crew/<project>/port`
-- **Persistence**: SQLite at `/tmp/agent_crew/<project>/agent_crew.db`
+- **Port**: auto-selected starting from 8100; written to `~/.agent_crew/<project>/port`
+- **Persistence**: SQLite at `~/.agent_crew/<project>/tasks.db`
 - **Atomicity**: dequeue (inside `/tasks/next` and inside push) wraps in a DB transaction — no double-assignment
 - **Crash recovery**: SQLite persists all state; on restart, pending/in_progress tasks are preserved. `crew recover` relaunches the server.
 - **Push model**: the server loads `pane_map.json` (`{role: pane_id}`) at startup and, on `POST /tasks`, delivers each task to the target role's pane via `tmux send-keys`. Agents do NOT poll — they receive tasks via pane input and POST results back. On `POST /tasks/{id}/result`, the server checks for more pending tasks of that role and pushes the next one automatically. Agents still may call `GET /tasks/next` for observability or recovery, but it is not the primary delivery path.
@@ -111,7 +111,7 @@ Conversational-agent CLIs (Claude, Codex, Gemini) don't reliably maintain a `whi
 
 Tracks tmux pane lifecycle per agent.
 
-**State file**: `/tmp/agent_crew/<project>/sessions.json`
+**State file**: `~/.agent_crew/<project>/state.json`
 
 ```json
 {
@@ -300,14 +300,20 @@ agent_crew/
 
 ```
 $HOME/.agent_crew/worktrees/<project>/<agent>/   git worktrees (persistent)
-/tmp/agent_crew/<project>/
+$HOME/.agent_crew/<project>/
   port              Task Queue server port
-  sessions.json     session state (including agent restart commands)
-  agent_crew.db     SQLite task + gate store
+  state.json        project state (port, session, pane_ids, pane_map, worktrees, db path)
+  sessions.json     per-agent session lifecycle (cmd, started_at, failures)
+  pane_map.json     role → pane_id mapping consumed by the push model
+  tasks.db          SQLite task + gate store
+  server.log        uvicorn stdout/stderr (background server)
+  crew.log          crew CLI activity log
   synthesis.md      discussion output (overwritten each run)
 ```
 
-Nothing written inside the user's git repo. All runtime state in `/tmp`.
+Nothing written inside the user's git repo. All runtime state in `$HOME/.agent_crew/`
+so it survives reboot — the queue, in-progress tasks, and pane bindings persist
+across sessions.
 
 ---
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -280,7 +280,7 @@ crew teardown <project>                               # cleanup worktrees + serv
 ## 11. Security
 
 - No credentials stored in any project file
-- All runtime state (`sessions.json`, `agent_crew.db`, `port`) lives in `/tmp` — not in repo
+- All runtime state (`state.json`, `sessions.json`, `tasks.db`, `port`) lives under `$HOME/.agent_crew/<project>/` — never in the user's git repo
 - All secrets passed via environment variables
 - Public repo must contain no user-specific paths, tokens, or hostnames
 
@@ -289,8 +289,9 @@ crew teardown <project>                               # cleanup worktrees + serv
 ## 12. Environment Variables
 
 ```
-AGENT_CREW_WORKTREES   base path for git worktrees (default: $HOME/.agent_crew/worktrees)
-AGENT_CREW_COMM_DIR    base path for comm dirs     (default: /tmp/agent_crew)
+AGENT_CREW_BASE        base path for per-project state + worktrees (default: $HOME/.agent_crew)
+AGENT_CREW_DB          SQLite task DB path (set per-project by `crew setup`; uvicorn fallback only)
+AGENT_CREW_PANE_MAP    pane_map.json path (set per-project by `crew setup`)
 AGENT_CREW_PORT        force a fixed server port   (default: auto, starting from 8100)
 SESSION_MAX_HOURS      session age before refresh  (default: 24)
 SESSION_MAX_FAILURES   consecutive failures before refresh (default: 2)

--- a/docs/test_plan.md
+++ b/docs/test_plan.md
@@ -17,7 +17,7 @@
 **Conventions**:
 - All tests under `tests/`
 - Fixtures in `tests/conftest.py`
-- Temp directories via `tmp_path` fixture (no real `/tmp/agent_crew` pollution)
+- Temp directories via `tmp_path` fixture (no real `~/.agent_crew` pollution)
 - SQLite uses `:memory:` or temp file for unit/integration tests
 
 ---
@@ -232,7 +232,7 @@ End-to-end tests using real CLI, tmux, and git. Run in isolated temp directory w
 ```bash
 # stub agent: reads task from server, writes a result
 #!/bin/bash
-PORT=$(cat /tmp/agent_crew/$PROJECT/port)
+PORT=$(cat ~/.agent_crew/$PROJECT/port)
 TASK=$(curl -s "http://localhost:$PORT/tasks/next?agent=$AGENT&role=$ROLE")
 # ... process task ...
 curl -s -X POST "http://localhost:$PORT/tasks/$TASK_ID/result" -d '{"status":"completed","summary":"done"}'


### PR DESCRIPTION
## Summary

`docs/{architecture,requirements,test_plan}.md` still listed runtime state (port, DB, sessions/state.json) under `/tmp/agent_crew/<project>/`. Real implementation has long since moved to `~/.agent_crew/<project>/` (state survives reboot), and the DB filename is `tasks.db`, not `agent_crew.db`. This PR brings the docs in line with what `crew setup` / `crew recover` actually write to disk.

## Changes

- `docs/architecture.md`
  - §2.1 port + persistence paths: `/tmp/agent_crew/...` → `~/.agent_crew/<project>/{port,tasks.db}`
  - §2.2 state file path: `/tmp/.../sessions.json` → `~/.agent_crew/<project>/state.json`
  - §4 directory listing: full set of files crew writes (state.json, sessions.json, pane_map.json, tasks.db, server.log, crew.log)
  - "All runtime state in /tmp" → "in \$HOME/.agent_crew/" with reboot-survivability note
- `docs/requirements.md`
  - §11 security: stale `/tmp` reference corrected
  - §12 env vars: drop unused `AGENT_CREW_COMM_DIR`; add `AGENT_CREW_BASE`, `AGENT_CREW_DB`, `AGENT_CREW_PANE_MAP`
- `docs/test_plan.md`
  - test convention + stub-agent example updated to `~/.agent_crew/`

## Test plan
- [ ] `grep -rn /tmp/agent_crew docs/` returns no hits
- [ ] No code changed — nothing to run

🤖 Generated with [Claude Code](https://claude.com/claude-code)