### PR TITLE
feat(#79): server-side telegram notify helper

### DIFF
--- a/src/agent_crew/notify.py
+++ b/src/agent_crew/notify.py
@@ -1,0 +1,60 @@
+"""Server-side telegram notification helper (Issue #79).
+
+Provides non-blocking, exception-safe notification functions for server lifecycle events.
+"""
+import os
+import sys
+from typing import Optional
+
+import httpx
+
+
+def notify_telegram(message: str, chat_id: Optional[str] = None) -> bool:
+    """Send a message to Telegram via Bot API.
+
+    Args:
+        message: The message text to send.
+        chat_id: Telegram chat ID. If None, reads from TELEGRAM_CHAT_ID env var.
+
+    Returns:
+        True if message was sent successfully (HTTP 200), False otherwise.
+        Never raises exceptions.
+    """
+    try:
+        bot_token = os.getenv("TELEGRAM_BOT_TOKEN")
+        if not bot_token:
+            return False
+
+        resolved_chat_id = chat_id or os.getenv("TELEGRAM_CHAT_ID")
+        if not resolved_chat_id:
+            return False
+
+        url = f"https://api.telegram.org/bot{bot_token}/sendMessage"
+        response = httpx.post(
+            url,
+            json={
+                "chat_id": resolved_chat_id,
+                "text": message,
+            },
+            timeout=5,
+        )
+
+        return response.status_code == 200
+    except Exception:
+        return False
+
+
+def notify_console(message: str) -> bool:
+    """Write a message to stderr as a fallback notification channel.
+
+    Args:
+        message: The message text to write.
+
+    Returns:
+        Always returns True.
+    """
+    try:
+        print(message, file=sys.stderr)
+        return True
+    except Exception:
+        return False

--- a/src/agent_crew/notify.py
+++ b/src/agent_crew/notify.py
@@ -25,7 +25,7 @@ def notify_telegram(message: str, chat_id: Optional[str] = None) -> bool:
         if not bot_token:
             return False
 
-        resolved_chat_id = chat_id or os.getenv("TELEGRAM_CHAT_ID")
+        resolved_chat_id = chat_id if chat_id is not None else os.getenv("TELEGRAM_CHAT_ID")
         if not resolved_chat_id:
             return False
 
@@ -55,6 +55,6 @@ def notify_console(message: str) -> bool:
     """
     try:
         print(message, file=sys.stderr)
-        return True
     except Exception:
-        return False
+        pass
+    return True

--- a/tests/unit/test_notify.py
+++ b/tests/unit/test_notify.py
@@ -1,0 +1,124 @@
+"""Unit tests for telegram notify helper (Issue #79)."""
+import io
+import sys
+from unittest.mock import Mock, patch, MagicMock
+
+import httpx
+import pytest
+
+from agent_crew.notify import notify_telegram, notify_console
+
+
+class TestNotifyTelegram:
+    """Tests for notify_telegram function."""
+
+    def test_missing_bot_token_returns_false_no_httpx_call(self):
+        """If TELEGRAM_BOT_TOKEN is absent, return False without calling httpx."""
+        with patch.dict("os.environ", {}, clear=True):
+            result = notify_telegram("test message", chat_id="123")
+            assert result is False
+
+    def test_missing_chat_id_env_and_no_arg_returns_false(self):
+        """If TELEGRAM_CHAT_ID missing from env and no chat_id arg, return False."""
+        with patch.dict("os.environ", {"TELEGRAM_BOT_TOKEN": "token123"}, clear=True):
+            result = notify_telegram("test message")
+            assert result is False
+
+    def test_http_200_returns_true(self):
+        """When httpx returns 200, notify_telegram returns True."""
+        with patch.dict("os.environ", {
+            "TELEGRAM_BOT_TOKEN": "token123",
+            "TELEGRAM_CHAT_ID": "chat456"
+        }):
+            with patch("agent_crew.notify.httpx.post") as mock_post:
+                mock_response = Mock()
+                mock_response.status_code = 200
+                mock_post.return_value = mock_response
+
+                result = notify_telegram("test message")
+                assert result is True
+                mock_post.assert_called_once()
+
+    def test_http_error_returns_false(self):
+        """When httpx returns error status, notify_telegram returns False."""
+        with patch.dict("os.environ", {
+            "TELEGRAM_BOT_TOKEN": "token123",
+            "TELEGRAM_CHAT_ID": "chat456"
+        }):
+            with patch("agent_crew.notify.httpx.post") as mock_post:
+                mock_response = Mock()
+                mock_response.status_code = 500
+                mock_post.return_value = mock_response
+
+                result = notify_telegram("test message")
+                assert result is False
+
+    def test_httpx_exception_returns_false(self):
+        """When httpx raises an exception, notify_telegram catches it and returns False."""
+        with patch.dict("os.environ", {
+            "TELEGRAM_BOT_TOKEN": "token123",
+            "TELEGRAM_CHAT_ID": "chat456"
+        }):
+            with patch("agent_crew.notify.httpx.post") as mock_post:
+                mock_post.side_effect = httpx.RequestError("Connection failed")
+
+                result = notify_telegram("test message")
+                assert result is False
+
+    def test_chat_id_arg_overrides_env(self):
+        """chat_id argument overrides TELEGRAM_CHAT_ID from environment."""
+        with patch.dict("os.environ", {
+            "TELEGRAM_BOT_TOKEN": "token123",
+            "TELEGRAM_CHAT_ID": "env_chat_id"
+        }):
+            with patch("agent_crew.notify.httpx.post") as mock_post:
+                mock_response = Mock()
+                mock_response.status_code = 200
+                mock_post.return_value = mock_response
+
+                notify_telegram("test message", chat_id="arg_chat_id")
+
+                # Verify the call was made with arg_chat_id, not env_chat_id
+                call_args = mock_post.call_args
+                assert call_args is not None
+                # The chat_id should be in the JSON data
+                json_data = call_args[1].get("json")
+                assert json_data["chat_id"] == "arg_chat_id"
+
+    def test_uses_5_second_timeout(self):
+        """notify_telegram uses a 5 second timeout."""
+        with patch.dict("os.environ", {
+            "TELEGRAM_BOT_TOKEN": "token123",
+            "TELEGRAM_CHAT_ID": "chat456"
+        }):
+            with patch("agent_crew.notify.httpx.post") as mock_post:
+                mock_response = Mock()
+                mock_response.status_code = 200
+                mock_post.return_value = mock_response
+
+                notify_telegram("test message")
+
+                call_args = mock_post.call_args
+                assert call_args[1].get("timeout") == 5
+
+
+class TestNotifyConsole:
+    """Tests for notify_console function."""
+
+    def test_writes_to_stderr_and_returns_true(self):
+        """notify_console writes message to stderr and returns True."""
+        stderr_capture = io.StringIO()
+
+        with patch("sys.stderr", stderr_capture):
+            result = notify_console("test alert message")
+
+        assert result is True
+        output = stderr_capture.getvalue()
+        assert "test alert message" in output
+
+    def test_always_returns_true(self):
+        """notify_console always returns True regardless of message."""
+        with patch("sys.stderr", io.StringIO()):
+            assert notify_console("message 1") is True
+            assert notify_console("") is True
+            assert notify_console("x" * 1000) is True

--- a/tests/unit/test_notify.py
+++ b/tests/unit/test_notify.py
@@ -15,8 +15,10 @@ class TestNotifyTelegram:
     def test_missing_bot_token_returns_false_no_httpx_call(self):
         """If TELEGRAM_BOT_TOKEN is absent, return False without calling httpx."""
         with patch.dict("os.environ", {}, clear=True):
-            result = notify_telegram("test message", chat_id="123")
-            assert result is False
+            with patch("agent_crew.notify.httpx.post") as mock_post:
+                result = notify_telegram("test message", chat_id="123")
+                assert result is False
+                mock_post.assert_not_called()
 
     def test_missing_chat_id_env_and_no_arg_returns_false(self):
         """If TELEGRAM_CHAT_ID missing from env and no chat_id arg, return False."""


### PR DESCRIPTION
## Summary

Implement telegram notification helper for server-side alerts (Issue #79).

- New module `src/agent_crew/notify.py` with two functions:
  - `notify_telegram(message, chat_id=None)` — POSTs to Telegram Bot API, returns bool
  - `notify_console(message)` — writes to stderr as fallback
- All exceptions caught, never raises
- Uses 5-second httpx timeout
- Reads `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` from env
- Argument `chat_id` overrides env variable

## Test plan

✅ All 9 new tests pass:
- Missing env var paths (TELEGRAM_BOT_TOKEN, TELEGRAM_CHAT_ID)
- HTTP success (200) and error (500, exceptions) paths
- Argument override behavior
- Timeout configuration
- Console stderr output

Closes #79