### PR TITLE
feat(#80): runtime wrong-repo monitor as lifespan background task

### DIFF
--- a/src/agent_crew/anomaly.py
+++ b/src/agent_crew/anomaly.py
@@ -1,0 +1,230 @@
+"""Runtime cross-project anomaly checks (Issue #80).
+
+The setup-time `validate_repo_origin()` cannot catch agents that drift to a
+different repo after they're running. This module polls the bot account's
+recent GitHub events and flags comments posted to repos outside the expected
+set, alerting via the notify helper from #79.
+"""
+import json
+import os
+import subprocess
+from typing import Any, Callable, Iterable, Optional
+
+import httpx
+
+from agent_crew.notify import notify_telegram
+
+COMMENT_EVENT_TYPES = (
+    "IssueCommentEvent",
+    "PullRequestReviewCommentEvent",
+    "CommitCommentEvent",
+    "PullRequestReviewEvent",
+)
+
+
+def _fetch_user_events(
+    username: str,
+    *,
+    token: Optional[str] = None,
+    per_page: int = 30,
+) -> list[dict]:
+    """Fetch recent public events for the given GitHub user.
+
+    Returns an empty list on any error so the caller never has to handle
+    network or auth failures.
+    """
+    headers = {"Accept": "application/vnd.github+json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    url = f"https://api.github.com/users/{username}/events"
+    try:
+        r = httpx.get(
+            url,
+            headers=headers,
+            params={"per_page": per_page},
+            timeout=10,
+        )
+        if r.status_code != 200:
+            return []
+        data = r.json()
+        return data if isinstance(data, list) else []
+    except Exception:
+        return []
+
+
+def _extract_repo_from_url(url: str) -> Optional[str]:
+    """Extract `owner/repo` from a GitHub remote URL (https or ssh)."""
+    if not url:
+        return None
+    url = url.strip().rstrip("/")
+    if url.endswith(".git"):
+        url = url[:-4]
+    if "github.com/" in url:
+        return url.split("github.com/", 1)[1] or None
+    if "github.com:" in url:
+        return url.split("github.com:", 1)[1] or None
+    return None
+
+
+def auto_detect_expected_repos(state_path: str) -> list[str]:
+    """Read state.json, scan each worktree's `git remote get-url origin`,
+    return a sorted list of `owner/repo` strings."""
+    try:
+        with open(state_path) as f:
+            state = json.load(f)
+    except Exception:
+        return []
+    repos: set[str] = set()
+    worktrees = state.get("worktrees") or {}
+    if not isinstance(worktrees, dict):
+        return []
+    for path in worktrees.values():
+        if not isinstance(path, str) or not path:
+            continue
+        try:
+            r = subprocess.run(
+                ["git", "-C", path, "remote", "get-url", "origin"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+        except Exception:
+            continue
+        if r.returncode != 0:
+            continue
+        repo = _extract_repo_from_url(r.stdout.strip())
+        if repo:
+            repos.add(repo)
+    return sorted(repos)
+
+
+def _build_alert_message(
+    username: str,
+    expected: Iterable[str],
+    details: list[dict],
+) -> str:
+    expected_list = ", ".join(sorted(set(expected))) or "(none)"
+    lines = [
+        f"⚠️ agent_crew wrong-repo alert ({username})",
+        f"Anomalies: {len(details)}",
+        f"Expected: {expected_list}",
+        "Details:",
+    ]
+    for d in details[:5]:
+        lines.append(
+            f"  - {d.get('type', '?')} on {d.get('repo', '?')}: {d.get('url') or '(no url)'}"
+        )
+    if len(details) > 5:
+        lines.append(f"  … and {len(details) - 5} more")
+    return "\n".join(lines)
+
+
+def check_wrong_repo(
+    expected_repos: Optional[list[str]] = None,
+    *,
+    username: Optional[str] = None,
+    state_path: Optional[str] = None,
+    fetch_events: Optional[Callable[..., list[dict]]] = None,
+    notify: Optional[Callable[[str], bool]] = None,
+) -> dict[str, Any]:
+    """Check recent comment events of the bot account for cross-project leakage.
+
+    Args:
+        expected_repos: Allow-list of `owner/repo`. If None, falls back to
+            `auto_detect_expected_repos(state_path)`.
+        username: Bot GitHub login. Defaults to `AGENT_CREW_GH_USERNAME`.
+        state_path: Path to the per-project state.json (used for auto-detect).
+        fetch_events: Injectable events fetcher (for tests). Defaults to the
+            real GitHub API call.
+        notify: Injectable notifier (for tests). Defaults to `notify_telegram`.
+
+    Returns:
+        {
+            "checked": <int>,           # number of comment events inspected
+            "anomalies": <int>,         # how many were outside expected_repos
+            "notified": <bool>,         # whether the alert was sent
+            "details": <list[dict]>,    # one entry per anomaly
+            "reason": <str | None>,     # short skip reason if checked == 0
+        }
+    """
+    resolved_username = (
+        username
+        or os.getenv("AGENT_CREW_GH_USERNAME")
+        or os.getenv("GITHUB_BOT_USERNAME")
+    )
+    if not resolved_username:
+        return {
+            "checked": 0,
+            "anomalies": 0,
+            "notified": False,
+            "details": [],
+            "reason": "missing username",
+        }
+
+    if expected_repos is None and state_path:
+        expected_repos = auto_detect_expected_repos(state_path)
+    if not expected_repos:
+        return {
+            "checked": 0,
+            "anomalies": 0,
+            "notified": False,
+            "details": [],
+            "reason": "no expected_repos",
+        }
+
+    fetch = fetch_events or _fetch_user_events
+    notifier = notify or notify_telegram
+    token = os.getenv("GH_TOKEN") or os.getenv("GITHUB_TOKEN")
+
+    try:
+        events = fetch(resolved_username, token=token)
+    except Exception:
+        events = []
+    if not isinstance(events, list):
+        events = []
+
+    expected_set = set(expected_repos)
+    details: list[dict] = []
+    checked = 0
+    for event in events:
+        if not isinstance(event, dict):
+            continue
+        if event.get("type") not in COMMENT_EVENT_TYPES:
+            continue
+        checked += 1
+        repo_info = event.get("repo") or {}
+        repo_name = repo_info.get("name", "") if isinstance(repo_info, dict) else ""
+        if repo_name and repo_name not in expected_set:
+            payload = event.get("payload") or {}
+            comment = payload.get("comment") if isinstance(payload, dict) else None
+            url = ""
+            if isinstance(comment, dict):
+                url = comment.get("html_url") or ""
+            elif isinstance(payload, dict):
+                review = payload.get("review")
+                if isinstance(review, dict):
+                    url = review.get("html_url") or ""
+            details.append(
+                {
+                    "type": event.get("type"),
+                    "repo": repo_name,
+                    "url": url,
+                    "created_at": event.get("created_at"),
+                }
+            )
+
+    notified = False
+    if details:
+        message = _build_alert_message(resolved_username, expected_set, details)
+        try:
+            notified = bool(notifier(message))
+        except Exception:
+            notified = False
+
+    return {
+        "checked": checked,
+        "anomalies": len(details),
+        "notified": notified,
+        "details": details,
+        "reason": None,
+    }

--- a/src/agent_crew/cli.py
+++ b/src/agent_crew/cli.py
@@ -434,11 +434,13 @@ def setup(project: str, agents: str, base: str):
     # AGENT_CREW_PANE_MAP tells the server where to push tasks; AGENT_CREW_PORT is
     # embedded in push messages so agents know where to POST results.
     db_file = os.path.join(proj_dir, "tasks.db")
+    state_file = _state_path(base, project)
     pythonpath = os.pathsep.join(p for p in sys.path if p)
     server_env = {
         **os.environ,
         "AGENT_CREW_DB": db_file,
         "AGENT_CREW_PANE_MAP": pane_map_file,
+        "AGENT_CREW_STATE": state_file,
         "AGENT_CREW_PORT": str(port),
         "PYTHONPATH": pythonpath,
     }
@@ -689,10 +691,12 @@ def recover(project: str, base: str):
     if not _port_listening(port, timeout=1.0):
         pythonpath = os.pathsep.join(p for p in sys.path if p)
         pane_map_file = os.path.join(proj_dir, "pane_map.json")
+        state_file = _state_path(base, project)
         server_env = {
             **os.environ,
             "AGENT_CREW_DB": db_file,
             "AGENT_CREW_PANE_MAP": pane_map_file,
+            "AGENT_CREW_STATE": state_file,
             "AGENT_CREW_PORT": str(port),
             "PYTHONPATH": pythonpath,
         }

--- a/src/agent_crew/server.py
+++ b/src/agent_crew/server.py
@@ -13,6 +13,7 @@ from typing import Callable, Literal, Optional
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 
+from agent_crew.anomaly import check_wrong_repo
 from agent_crew.protocol import GateRequest, TaskRequest, TaskResult
 from agent_crew.queue import TaskQueue, _ROLE_TO_TYPE, _TYPE_TO_ROLE
 
@@ -199,6 +200,9 @@ def create_app(
     reminder_seconds: Optional[float] = None,
     timeout_seconds: Optional[float] = None,
     watchdog_disabled: Optional[bool] = None,
+    anomaly_interval: Optional[float] = None,
+    anomaly_disabled: Optional[bool] = None,
+    state_path: Optional[str] = None,
 ) -> FastAPI:
     """
     pane_map: {role: pane_id} — e.g. {"implementer": "%475"}. If None, push is disabled.
@@ -216,6 +220,13 @@ def create_app(
         Falls back to env ``AGENT_CREW_TIMEOUT_SECONDS`` then 900s.
     watchdog_disabled: skip the background loop entirely (tests). Falls back
         to env ``AGENT_CREW_WATCHDOG_DISABLED``.
+    anomaly_interval: seconds between wrong-repo anomaly sweeps (Issue #80).
+        Falls back to env ``AGENT_CREW_ANOMALY_INTERVAL`` then 600s.
+    anomaly_disabled: skip the anomaly sweep entirely. Falls back to
+        ``AGENT_CREW_ANOMALY_DISABLED`` (or auto-disabled when no
+        ``AGENT_CREW_GH_USERNAME`` is configured).
+    state_path: path to the per-project state.json — used by the anomaly
+        sweep to auto-detect the expected repo allow-list.
     """
     if watchdog_interval is None:
         watchdog_interval = float(os.getenv("AGENT_CREW_WATCHDOG_INTERVAL", "30"))
@@ -227,6 +238,12 @@ def create_app(
         watchdog_disabled = os.getenv("AGENT_CREW_WATCHDOG_DISABLED", "").lower() in (
             "1", "true", "yes",
         )
+    if anomaly_interval is None:
+        anomaly_interval = float(os.getenv("AGENT_CREW_ANOMALY_INTERVAL", "600"))
+    if anomaly_disabled is None:
+        anomaly_disabled = os.getenv("AGENT_CREW_ANOMALY_DISABLED", "").lower() in (
+            "1", "true", "yes",
+        )
 
     state: dict = {}
     reminded_task_ids: set[str] = set()
@@ -234,16 +251,19 @@ def create_app(
     @asynccontextmanager
     async def lifespan(app: FastAPI):
         state["queue"] = TaskQueue(db_path)
-        watchdog_task = None
+        background_tasks: list[asyncio.Task] = []
         if not watchdog_disabled:
-            watchdog_task = asyncio.create_task(_watchdog_loop())
+            background_tasks.append(asyncio.create_task(_watchdog_loop()))
+        if not anomaly_disabled:
+            background_tasks.append(asyncio.create_task(_anomaly_loop()))
         try:
             yield
         finally:
-            if watchdog_task is not None:
-                watchdog_task.cancel()
+            for task in background_tasks:
+                task.cancel()
+            for task in background_tasks:
                 with contextlib.suppress(asyncio.CancelledError, Exception):
-                    await watchdog_task
+                    await task
 
     app = FastAPI(lifespan=lifespan)
 
@@ -433,6 +453,30 @@ def create_app(
                     _watchdog_tick(time.time())
                 except Exception:
                     logger.exception("watchdog tick raised — continuing")
+        except asyncio.CancelledError:
+            return
+
+    def _anomaly_tick() -> dict:
+        """Sync entry point for the wrong-repo anomaly sweep (Issue #80)."""
+        return check_wrong_repo(state_path=state_path)
+
+    # Stash for tests (drive without the asyncio loop).
+    app.state.anomaly_tick = _anomaly_tick
+
+    async def _anomaly_loop() -> None:
+        """Periodic wrong-repo sweep. Cancels cleanly on shutdown."""
+        try:
+            while True:
+                await asyncio.sleep(anomaly_interval)
+                try:
+                    result = _anomaly_tick()
+                    if result.get("anomalies"):
+                        logger.warning(
+                            f"anomaly sweep: {result['anomalies']} wrong-repo events "
+                            f"(notified={result.get('notified')})"
+                        )
+                except Exception:
+                    logger.exception("anomaly tick raised — continuing")
         except asyncio.CancelledError:
             return
 
@@ -748,4 +792,5 @@ app = create_app(
     db_path=os.path.expanduser(os.getenv("AGENT_CREW_DB", "/tmp/agent_crew_default.db")),
     pane_map=_load_pane_map(),
     port=int(os.getenv("AGENT_CREW_PORT", "0") or 0),
+    state_path=os.path.expanduser(os.getenv("AGENT_CREW_STATE", "")) or None,
 )

--- a/tests/unit/test_anomaly.py
+++ b/tests/unit/test_anomaly.py
@@ -1,0 +1,284 @@
+"""Unit tests for the runtime wrong-repo monitor (Issue #80)."""
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+from agent_crew.anomaly import (
+    _extract_repo_from_url,
+    auto_detect_expected_repos,
+    check_wrong_repo,
+)
+
+
+def _event(type_: str, repo: str, *, url: str = "", created_at: str = "2026-04-26T00:00:00Z") -> dict:
+    return {
+        "type": type_,
+        "repo": {"name": repo},
+        "payload": {"comment": {"html_url": url}},
+        "created_at": created_at,
+    }
+
+
+# ---------------------------------------------------------------------------
+# _extract_repo_from_url
+# ---------------------------------------------------------------------------
+
+
+class TestExtractRepoFromUrl:
+    def test_https_with_dot_git(self):
+        assert _extract_repo_from_url("https://github.com/owner/repo.git") == "owner/repo"
+
+    def test_https_no_dot_git(self):
+        assert _extract_repo_from_url("https://github.com/owner/repo") == "owner/repo"
+
+    def test_ssh(self):
+        assert _extract_repo_from_url("git@github.com:owner/repo.git") == "owner/repo"
+
+    def test_trailing_slash(self):
+        assert _extract_repo_from_url("https://github.com/owner/repo/") == "owner/repo"
+
+    def test_empty(self):
+        assert _extract_repo_from_url("") is None
+
+    def test_non_github(self):
+        assert _extract_repo_from_url("https://gitlab.com/owner/repo.git") is None
+
+
+# ---------------------------------------------------------------------------
+# auto_detect_expected_repos
+# ---------------------------------------------------------------------------
+
+
+class TestAutoDetectExpectedRepos:
+    def test_returns_owner_repo_for_each_worktree(self, tmp_path):
+        state_path = tmp_path / "state.json"
+        state_path.write_text(
+            json.dumps(
+                {
+                    "worktrees": {
+                        "claude": str(tmp_path / "claude"),
+                        "codex": str(tmp_path / "codex"),
+                    }
+                }
+            )
+        )
+
+        def fake_run(cmd, **kwargs):
+            mock = MagicMock()
+            mock.returncode = 0
+            if cmd[2].endswith("claude"):
+                mock.stdout = "https://github.com/me/proj.git\n"
+            else:
+                mock.stdout = "git@github.com:me/proj.git\n"
+            return mock
+
+        with patch("agent_crew.anomaly.subprocess.run", side_effect=fake_run):
+            repos = auto_detect_expected_repos(str(state_path))
+
+        assert repos == ["me/proj"]
+
+    def test_missing_state_returns_empty(self, tmp_path):
+        assert auto_detect_expected_repos(str(tmp_path / "missing.json")) == []
+
+    def test_malformed_state_returns_empty(self, tmp_path):
+        state_path = tmp_path / "state.json"
+        state_path.write_text("not json")
+        assert auto_detect_expected_repos(str(state_path)) == []
+
+    def test_remote_failure_skipped(self, tmp_path):
+        state_path = tmp_path / "state.json"
+        state_path.write_text(
+            json.dumps({"worktrees": {"claude": str(tmp_path / "claude")}})
+        )
+        mock = MagicMock(returncode=128, stdout="", stderr="not a git repo")
+        with patch("agent_crew.anomaly.subprocess.run", return_value=mock):
+            assert auto_detect_expected_repos(str(state_path)) == []
+
+
+# ---------------------------------------------------------------------------
+# check_wrong_repo
+# ---------------------------------------------------------------------------
+
+
+class TestCheckWrongRepo:
+    def test_missing_username_returns_skip(self):
+        with patch.dict(os.environ, {}, clear=True):
+            result = check_wrong_repo(expected_repos=["a/b"])
+        assert result["checked"] == 0
+        assert result["anomalies"] == 0
+        assert result["reason"] == "missing username"
+
+    def test_no_expected_repos_returns_skip(self):
+        result = check_wrong_repo(
+            expected_repos=[],
+            username="bot",
+            fetch_events=lambda *a, **kw: [],
+            notify=lambda m: True,
+        )
+        assert result["reason"] == "no expected_repos"
+        assert result["notified"] is False
+
+    def test_no_anomalies_no_notify(self):
+        events = [
+            _event("IssueCommentEvent", "me/proj"),
+            _event("PushEvent", "someone/else"),  # not a comment type → ignored
+            _event("PullRequestReviewEvent", "me/proj"),
+        ]
+        notify_calls = []
+        result = check_wrong_repo(
+            expected_repos=["me/proj"],
+            username="bot",
+            fetch_events=lambda *a, **kw: events,
+            notify=lambda m: (notify_calls.append(m), True)[1],
+        )
+        assert result["checked"] == 2
+        assert result["anomalies"] == 0
+        assert result["notified"] is False
+        assert notify_calls == []
+
+    def test_anomaly_detected_triggers_notify(self):
+        events = [
+            _event("IssueCommentEvent", "me/proj"),
+            _event(
+                "IssueCommentEvent",
+                "stranger/danger",
+                url="https://github.com/stranger/danger/issues/1#issuecomment-1",
+            ),
+            _event("CommitCommentEvent", "another/wrong"),
+        ]
+        notify_calls = []
+        result = check_wrong_repo(
+            expected_repos=["me/proj"],
+            username="bot",
+            fetch_events=lambda *a, **kw: events,
+            notify=lambda m: (notify_calls.append(m), True)[1],
+        )
+        assert result["checked"] == 3
+        assert result["anomalies"] == 2
+        assert result["notified"] is True
+        assert {d["repo"] for d in result["details"]} == {"stranger/danger", "another/wrong"}
+        assert len(notify_calls) == 1
+        msg = notify_calls[0]
+        assert "stranger/danger" in msg
+        assert "another/wrong" in msg
+        assert "bot" in msg
+
+    def test_username_from_env_when_arg_omitted(self, monkeypatch):
+        monkeypatch.setenv("AGENT_CREW_GH_USERNAME", "envbot")
+        captured_user = []
+        result = check_wrong_repo(
+            expected_repos=["me/proj"],
+            fetch_events=lambda u, **kw: (captured_user.append(u), [])[1],
+        )
+        assert captured_user == ["envbot"]
+        assert result["reason"] is None
+
+    def test_expected_repos_auto_detected_from_state(self, tmp_path, monkeypatch):
+        state_path = tmp_path / "state.json"
+        state_path.write_text(
+            json.dumps({"worktrees": {"claude": str(tmp_path / "claude")}})
+        )
+        monkeypatch.setattr(
+            "agent_crew.anomaly.subprocess.run",
+            lambda *a, **kw: MagicMock(returncode=0, stdout="https://github.com/me/proj.git"),
+        )
+        events = [_event("IssueCommentEvent", "stranger/repo")]
+        result = check_wrong_repo(
+            username="bot",
+            state_path=str(state_path),
+            fetch_events=lambda *a, **kw: events,
+            notify=lambda m: True,
+        )
+        assert result["anomalies"] == 1
+
+    def test_fetch_exception_swallowed(self):
+        def boom(*a, **kw):
+            raise RuntimeError("network down")
+
+        result = check_wrong_repo(
+            expected_repos=["me/proj"],
+            username="bot",
+            fetch_events=boom,
+            notify=lambda m: True,
+        )
+        assert result["checked"] == 0
+        assert result["anomalies"] == 0
+        assert result["notified"] is False
+
+    def test_notify_returning_false_recorded(self):
+        events = [_event("IssueCommentEvent", "stranger/repo")]
+        result = check_wrong_repo(
+            expected_repos=["me/proj"],
+            username="bot",
+            fetch_events=lambda *a, **kw: events,
+            notify=lambda m: False,
+        )
+        assert result["anomalies"] == 1
+        assert result["notified"] is False
+
+    def test_create_app_anomaly_disabled_via_env(self, tmp_db, monkeypatch):
+        """When AGENT_CREW_ANOMALY_DISABLED=1, lifespan must not start the loop."""
+        from fastapi.testclient import TestClient
+
+        from agent_crew.server import create_app
+
+        monkeypatch.setenv("AGENT_CREW_ANOMALY_DISABLED", "1")
+        app = create_app(db_path=tmp_db, watchdog_disabled=True)
+        # Tick is still callable (returns skip with reason since no username configured).
+        with TestClient(app) as _client:
+            result = app.state.anomaly_tick()
+            assert result["checked"] == 0
+            assert result["reason"] in ("missing username", "no expected_repos")
+
+    def test_create_app_anomaly_loop_runs_and_cancels(self, tmp_db, monkeypatch):
+        """Background loop fires the tick at least once and cancels cleanly."""
+        import time as _t
+
+        from fastapi.testclient import TestClient
+
+        from agent_crew.server import create_app
+
+        # Force the loop active with a very short interval. Inject a stub fetcher
+        # via env so the real GitHub call is never made.
+        monkeypatch.setenv("AGENT_CREW_GH_USERNAME", "stubbot")
+
+        # Create a state.json with no worktrees so auto_detect returns []
+        # → check_wrong_repo returns "no expected_repos" without HTTP.
+        import json
+        import os
+
+        state_path = os.path.join(os.path.dirname(tmp_db), "state.json")
+        with open(state_path, "w") as f:
+            json.dump({"worktrees": {}}, f)
+
+        app = create_app(
+            db_path=tmp_db,
+            watchdog_disabled=True,
+            anomaly_disabled=False,
+            anomaly_interval=0.05,
+            state_path=state_path,
+        )
+        with TestClient(app):
+            _t.sleep(0.2)  # give the loop a couple of ticks
+        # Reaching here without hanging proves cancel() worked.
+
+    def test_pull_request_review_event_url_falls_back_to_review(self):
+        events = [
+            {
+                "type": "PullRequestReviewEvent",
+                "repo": {"name": "stranger/repo"},
+                "payload": {
+                    "review": {"html_url": "https://github.com/stranger/repo/pull/1#review"}
+                },
+                "created_at": "2026-04-26T00:00:00Z",
+            }
+        ]
+        notify_calls = []
+        result = check_wrong_repo(
+            expected_repos=["me/proj"],
+            username="bot",
+            fetch_events=lambda *a, **kw: events,
+            notify=lambda m: (notify_calls.append(m), True)[1],
+        )
+        assert result["details"][0]["url"].endswith("#review")
+        assert "stranger/repo" in notify_calls[0]


### PR DESCRIPTION
## Summary

Closes #80. Adds `agent_crew/anomaly.py` with a runtime wrong-repo monitor that polls the bot account's recent GitHub events and alerts (via the #79 telegram notify helper) whenever a comment lands on a repo outside the expected allow-list. Mirrors the alpha_engine watchdog that caught real cross-project leakage incidents (their #383). Plugged into `server.py` as a second background lifespan task next to the heartbeat watchdog from #76/#77, and into `cli.py` so `crew setup` / `crew recover` provide the per-project state path needed for repo auto-detection.

## Architecture

- **Pure core**: `check_wrong_repo()` takes injectable `fetch_events` and `notify` callables, swallows all exceptions, and returns `{"checked", "anomalies", "notified", "details", "reason"}`. Easy to unit-test, easy to drop into a CLI command later.
- **Auto-detection**: when `expected_repos` is omitted, the function reads the per-project `state.json` and runs `git remote get-url origin` against each worktree, deriving `owner/repo` from the URL.
- **Lifespan integration**: `create_app(...)` gains three new parameters (`anomaly_interval`, `anomaly_disabled`, `state_path`) with env fallbacks. The new `_anomaly_loop` is started/cancelled alongside the existing watchdog using a single background-tasks list.
- **Failure-safe**: missing GH username, no expected_repos, network errors — all return a skip without crashing. The lifespan handler catches anything that escapes `_anomaly_tick` and continues, just like the watchdog.

## Env vars (new)

| Name | Default | Purpose |
|------|---------|---------|
| `AGENT_CREW_GH_USERNAME` | _(required for activation)_ | Bot login. Without it, the loop runs but each tick skips. |
| `AGENT_CREW_ANOMALY_INTERVAL` | `600` | Seconds between sweeps. |
| `AGENT_CREW_ANOMALY_DISABLED` | _(unset)_ | `1`/`true`/`yes` skips the loop entirely. |
| `AGENT_CREW_STATE` | _(set by crew CLI)_ | Path to `state.json` for repo auto-detection. |

`GH_TOKEN` / `GITHUB_TOKEN` is read for authenticated event fetches (raises rate-limit ceiling).

## Test plan

- [x] `pytest tests/unit/test_anomaly.py -v` — 21 tests cover URL parsing, state auto-detect, anomaly detection, env username, fetch exceptions, notify=False propagation, and the full `create_app` lifespan path.
- [x] `pytest tests/unit -q` — 205/208 pass; the 3 failing test_cli `test_u_c20/21/22` are pre-existing (issue #88), unrelated to this change.
- [ ] Manual smoke after merge: set `AGENT_CREW_GH_USERNAME=truhojunbot-tech`, watch `server.log` for an anomaly tick at the configured interval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)