### PR TITLE
feat(#81): rate-limit auto-fallback with chain config + escalation gate

### DIFF
--- a/src/agent_crew/fallback.py
+++ b/src/agent_crew/fallback.py
@@ -1,0 +1,138 @@
+"""Agent rate-limit auto-fallback policy (Issue #81).
+
+When a task comes back ``status="failed"`` because the agent's provider hit
+its rate limit, single-agent retry just rebroadcasts the same problem. The
+fallback policy reroutes the same task to the next agent in a configurable
+chain (claude → codex → gemini, etc.) and only escalates once the chain is
+exhausted.
+
+This module is deliberately stateless and pure — `server.py` calls these
+functions inside the existing ``submit_result`` handler. Tests can drive
+each function directly without spinning up FastAPI.
+"""
+import json
+import os
+import re
+from typing import Any, Optional
+
+# Patterns surfaced by alpha_engine #756 / #759 across the three providers we
+# routinely run. Compiled case-insensitively. Add new ones here when an
+# additional provider message starts leaking through.
+_RATE_LIMIT_PATTERNS: tuple[str, ...] = (
+    r"usage limit",          # codex / openai
+    r"rate[- ]?limit",       # claude / generic
+    r"quota exceeded",       # gemini / google
+    r"5[- ]hour limit",      # claude (rolling-window message)
+    r"max requests",         # generic
+    r"too many requests",    # http 429
+    r"resource[_ ]exhausted",  # google "resource_exhausted"
+    r"insufficient[_ ]quota",  # openai
+)
+
+_RATE_LIMIT_RE = re.compile("|".join(_RATE_LIMIT_PATTERNS), re.IGNORECASE)
+
+DEFAULT_CHAINS: dict[str, list[str]] = {
+    "implement": ["claude", "codex", "gemini"],
+    "review":    ["codex",  "claude", "gemini"],
+    "test":      ["gemini", "codex",  "claude"],
+}
+
+
+def is_rate_limit_error(text: Optional[str]) -> bool:
+    """Return True if `text` matches any known rate-limit signature."""
+    if not text:
+        return False
+    return _RATE_LIMIT_RE.search(text) is not None
+
+
+def has_rate_limit_signal(summary: Optional[str], findings: Optional[list]) -> bool:
+    """Check whether either the summary or any finding indicates a rate-limit hit."""
+    if is_rate_limit_error(summary):
+        return True
+    if not findings:
+        return False
+    for f in findings:
+        if isinstance(f, str) and is_rate_limit_error(f):
+            return True
+        if isinstance(f, dict):
+            for value in f.values():
+                if isinstance(value, str) and is_rate_limit_error(value):
+                    return True
+    return False
+
+
+def load_fallback_chains(state_path: Optional[str]) -> dict[str, list[str]]:
+    """Read the per-project fallback chain override and merge over defaults.
+
+    Override file lives next to ``state.json`` at ``fallback_chains.json``.
+    Missing file or malformed JSON quietly returns the defaults; we never
+    want a config typo to disable the fallback policy.
+    """
+    chains: dict[str, list[str]] = {k: list(v) for k, v in DEFAULT_CHAINS.items()}
+    if not state_path:
+        return chains
+    override_path = os.path.join(os.path.dirname(state_path), "fallback_chains.json")
+    if not os.path.isfile(override_path):
+        return chains
+    try:
+        with open(override_path) as f:
+            raw = json.load(f)
+    except Exception:
+        return chains
+    if not isinstance(raw, dict):
+        return chains
+    for task_type, agents in raw.items():
+        if not isinstance(agents, list):
+            continue
+        cleaned = [a for a in agents if isinstance(a, str) and a]
+        if cleaned:
+            chains[task_type] = cleaned
+    return chains
+
+
+def next_agent(
+    task_type: str,
+    current_agent: Optional[str],
+    excluded: Optional[list[str]],
+    chains: Optional[dict[str, list[str]]] = None,
+) -> Optional[str]:
+    """Pick the next agent in the fallback chain.
+
+    Strategy:
+    1. If ``current_agent`` is in the chain, the next candidate is whatever
+       comes after it.
+    2. Otherwise (current agent is unknown or already past the chain), start
+       from the head.
+    3. Skip anything in ``excluded``. Returns ``None`` when the chain is
+       exhausted.
+    """
+    chain = (chains or DEFAULT_CHAINS).get(task_type, [])
+    excluded_set = set(excluded or [])
+    if current_agent and current_agent in excluded_set:
+        pass  # current agent already excluded; just walk from start
+    if current_agent and current_agent in chain:
+        idx = chain.index(current_agent)
+        candidates = chain[idx + 1:]
+    else:
+        candidates = chain
+    for agent in candidates:
+        if agent not in excluded_set:
+            return agent
+    return None
+
+
+def default_agent_for_role(role: str, pane_map: dict[str, Any]) -> Optional[str]:
+    """Reverse-lookup the canonical agent name (claude/codex/gemini) for a role.
+
+    `pane_map` carries both role keys and agent keys mapped to pane_ids.
+    The agent that shares the same pane as the role is the default for it.
+    """
+    if not pane_map:
+        return None
+    role_pane = pane_map.get(role)
+    if not role_pane:
+        return None
+    for k, v in pane_map.items():
+        if v == role_pane and k in ("claude", "codex", "gemini"):
+            return k
+    return None

--- a/src/agent_crew/server.py
+++ b/src/agent_crew/server.py
@@ -14,6 +14,13 @@ from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 
 from agent_crew.anomaly import check_wrong_repo
+from agent_crew.fallback import (
+    default_agent_for_role,
+    has_rate_limit_signal,
+    load_fallback_chains,
+    next_agent,
+)
+from agent_crew.notify import notify_telegram
 from agent_crew.protocol import GateRequest, TaskRequest, TaskResult
 from agent_crew.queue import TaskQueue, _ROLE_TO_TYPE, _TYPE_TO_ROLE
 
@@ -203,6 +210,7 @@ def create_app(
     anomaly_interval: Optional[float] = None,
     anomaly_disabled: Optional[bool] = None,
     state_path: Optional[str] = None,
+    fallback_disabled: Optional[bool] = None,
 ) -> FastAPI:
     """
     pane_map: {role: pane_id} — e.g. {"implementer": "%475"}. If None, push is disabled.
@@ -242,6 +250,10 @@ def create_app(
         anomaly_interval = float(os.getenv("AGENT_CREW_ANOMALY_INTERVAL", "600"))
     if anomaly_disabled is None:
         anomaly_disabled = os.getenv("AGENT_CREW_ANOMALY_DISABLED", "").lower() in (
+            "1", "true", "yes",
+        )
+    if fallback_disabled is None:
+        fallback_disabled = os.getenv("AGENT_CREW_FALLBACK_DISABLED", "").lower() in (
             "1", "true", "yes",
         )
 
@@ -602,6 +614,101 @@ def create_app(
             logger.warning(f"Failed to auto-retry task {task_id}: {e}")
             pass
 
+    def _auto_fallback_failed_task(
+        task_id: str,
+        result: TaskResult,
+        task_type: str,
+    ) -> bool:
+        """If the failure is rate-limit-shaped, reroute to the next agent in
+        the fallback chain. Returns True when fallback handled the task
+        (caller should skip auto_retry); False when caller should fall through
+        to the normal retry path.
+
+        On chain exhaustion, opens an ``escalation`` gate and tries to send a
+        Telegram alert via the #79 helper (best-effort).
+        """
+        if fallback_disabled:
+            return False
+        if not has_rate_limit_signal(result.summary, result.findings):
+            return False
+
+        try:
+            tasks = [t for t in q().list_tasks() if t.task_id == task_id]
+            if not tasks:
+                return False
+            original = tasks[0]
+            ctx = dict(original.context) if isinstance(original.context, dict) else {}
+
+            role = _TYPE_TO_ROLE.get(task_type)
+            current_agent = (
+                ctx.get("agent_override")
+                or (default_agent_for_role(role, pane_map) if (role and pane_map) else None)
+            )
+            excluded = list(ctx.get("fallback_excluded") or [])
+            if current_agent and current_agent not in excluded:
+                excluded.append(current_agent)
+
+            chains = load_fallback_chains(state_path)
+            successor = next_agent(task_type, current_agent, excluded, chains)
+
+            if successor is None:
+                # Chain exhausted — escalate.
+                logger.warning(
+                    f"_auto_fallback: chain exhausted for {task_id} "
+                    f"(task_type={task_type}, excluded={excluded}). Escalating."
+                )
+                msg = (
+                    f"agent_crew rate-limit fallback exhausted\n"
+                    f"task_id: {task_id}\n"
+                    f"task_type: {task_type}\n"
+                    f"tried agents: {', '.join(excluded) or '(none)'}\n"
+                    f"last summary: {(result.summary or '')[:200]}"
+                )
+                try:
+                    q().create_gate(
+                        GateRequest(
+                            id=f"escalation-{task_id}-{uuid.uuid4().hex[:4]}",
+                            type="escalation",
+                            message=msg,
+                            status="pending",
+                        )
+                    )
+                except Exception as e:
+                    logger.warning(f"_auto_fallback: failed to create escalation gate: {e}")
+                try:
+                    notify_telegram(msg)
+                except Exception:
+                    pass
+                return True
+
+            new_ctx = dict(ctx)
+            new_ctx["agent_override"] = successor
+            new_ctx["fallback_excluded"] = excluded
+            new_ctx["fallback_from_task_id"] = task_id
+            try:
+                fallback_req = TaskRequest(
+                    task_id=f"fallback-{task_id}-{uuid.uuid4().hex[:4]}",
+                    task_type=task_type,  # type: ignore
+                    description=original.description,
+                    branch=original.branch,
+                    priority=original.priority,
+                    context=new_ctx,
+                )
+                q().enqueue(fallback_req)
+                logger.info(
+                    f"_auto_fallback: rerouted {task_id} -> {successor} "
+                    f"(excluded={excluded})"
+                )
+                if role:
+                    _try_push_next(role)
+                return True
+            except Exception as e:
+                logger.warning(f"_auto_fallback: enqueue failed for {task_id}: {e}")
+                return False
+        except Exception as e:
+            logger.warning(f"_auto_fallback: unexpected error for {task_id}: {e}")
+            return False
+
     @app.get("/health")
     def health():
         return {"status": "ok"}
@@ -663,10 +770,12 @@ def create_app(
             logger.info(f"POST /tasks/{task_id}/result: discuss task, pushing next discuss for agent={agent}")
             _try_push_discuss(agent)
         else:
-            # Auto-retry: failed task → auto-enqueue retry task (if under max retries)
+            # Failure handling: rate-limit → reroute via fallback chain (#81),
+            # otherwise auto-retry the same role up to MAX_RETRIES.
             if result.status == "failed":
-                logger.info(f"POST /tasks/{task_id}/result: task failed with status=failed, attempting auto-retry")
-                _auto_retry_failed_task(task_id, result, task_type)
+                logger.info(f"POST /tasks/{task_id}/result: task failed with status=failed, evaluating fallback/retry")
+                if not _auto_fallback_failed_task(task_id, result, task_type):
+                    _auto_retry_failed_task(task_id, result, task_type)
             # Auto-transition: impl task completed → auto-enqueue review task
             if task_type == "implement" and result.status == "completed":
                 logger.info(f"POST /tasks/{task_id}/result: impl task completed, auto-enqueueing review")

--- a/tests/unit/test_fallback.py
+++ b/tests/unit/test_fallback.py
@@ -1,0 +1,200 @@
+"""Unit tests for rate-limit auto-fallback (Issue #81)."""
+import json
+
+from agent_crew.fallback import (
+    DEFAULT_CHAINS,
+    default_agent_for_role,
+    has_rate_limit_signal,
+    is_rate_limit_error,
+    load_fallback_chains,
+    next_agent,
+)
+
+
+# ---------------------------------------------------------------------------
+# is_rate_limit_error
+# ---------------------------------------------------------------------------
+
+
+class TestIsRateLimitError:
+    def test_claude_rate_limit(self):
+        assert is_rate_limit_error("Claude 5-hour limit reached. Try again later.") is True
+        assert is_rate_limit_error("Anthropic API rate-limit exceeded") is True
+
+    def test_codex_usage_limit(self):
+        assert is_rate_limit_error("usage limit on the gpt-5 family") is True
+
+    def test_gemini_quota(self):
+        assert is_rate_limit_error("Quota exceeded for project 12345") is True
+        assert is_rate_limit_error("RESOURCE_EXHAUSTED: requests-per-minute") is True
+
+    def test_generic_429(self):
+        assert is_rate_limit_error("HTTP 429 Too Many Requests") is True
+
+    def test_openai_quota(self):
+        assert is_rate_limit_error("insufficient_quota: please check your plan") is True
+
+    def test_max_requests(self):
+        assert is_rate_limit_error("max requests per day reached") is True
+
+    def test_case_insensitive(self):
+        assert is_rate_limit_error("RATE LIMIT") is True
+        assert is_rate_limit_error("Usage Limit") is True
+
+    def test_non_rate_limit_failures(self):
+        assert is_rate_limit_error("syntax error in test_file.py") is False
+        assert is_rate_limit_error("ConnectionError: DNS lookup failed") is False
+        assert is_rate_limit_error("Failed to merge PR — conflicts present") is False
+
+    def test_none_and_empty(self):
+        assert is_rate_limit_error(None) is False
+        assert is_rate_limit_error("") is False
+
+
+class TestHasRateLimitSignal:
+    def test_summary_only(self):
+        assert has_rate_limit_signal("Hit usage limit", []) is True
+
+    def test_findings_string(self):
+        assert has_rate_limit_signal("ok", ["build failed", "rate limit hit"]) is True
+
+    def test_findings_dict_value(self):
+        assert (
+            has_rate_limit_signal(
+                "ok",
+                [{"layer": "build", "message": "quota exceeded"}],
+            )
+            is True
+        )
+
+    def test_no_signal(self):
+        assert (
+            has_rate_limit_signal(
+                "tests passed but lint failed",
+                [{"layer": "lint", "message": "unused import"}],
+            )
+            is False
+        )
+
+    def test_empty_inputs(self):
+        assert has_rate_limit_signal(None, None) is False
+        assert has_rate_limit_signal("", []) is False
+
+
+# ---------------------------------------------------------------------------
+# load_fallback_chains
+# ---------------------------------------------------------------------------
+
+
+class TestLoadFallbackChains:
+    def test_no_state_returns_defaults(self):
+        chains = load_fallback_chains(None)
+        assert chains == DEFAULT_CHAINS
+        # Returned dict must be a copy — mutation should not affect defaults
+        chains["implement"].append("rogue")
+        assert "rogue" not in DEFAULT_CHAINS["implement"]
+
+    def test_missing_override_returns_defaults(self, tmp_path):
+        state_path = str(tmp_path / "state.json")
+        chains = load_fallback_chains(state_path)
+        assert chains == DEFAULT_CHAINS
+
+    def test_override_merges_over_defaults(self, tmp_path):
+        state_path = tmp_path / "state.json"
+        state_path.write_text("{}")
+        override_path = tmp_path / "fallback_chains.json"
+        override_path.write_text(
+            json.dumps({"implement": ["codex", "claude"]})
+        )
+        chains = load_fallback_chains(str(state_path))
+        assert chains["implement"] == ["codex", "claude"]
+        # Other task_types fall back to defaults
+        assert chains["review"] == DEFAULT_CHAINS["review"]
+        assert chains["test"] == DEFAULT_CHAINS["test"]
+
+    def test_malformed_override_returns_defaults(self, tmp_path):
+        state_path = tmp_path / "state.json"
+        state_path.write_text("{}")
+        override_path = tmp_path / "fallback_chains.json"
+        override_path.write_text("not json at all")
+        assert load_fallback_chains(str(state_path)) == DEFAULT_CHAINS
+
+    def test_override_with_non_list_value_ignored(self, tmp_path):
+        state_path = tmp_path / "state.json"
+        state_path.write_text("{}")
+        override_path = tmp_path / "fallback_chains.json"
+        override_path.write_text(json.dumps({"implement": "claude"}))
+        # Non-list value silently ignored
+        chains = load_fallback_chains(str(state_path))
+        assert chains["implement"] == DEFAULT_CHAINS["implement"]
+
+    def test_override_filters_non_string_entries(self, tmp_path):
+        state_path = tmp_path / "state.json"
+        state_path.write_text("{}")
+        override_path = tmp_path / "fallback_chains.json"
+        override_path.write_text(
+            json.dumps({"implement": ["codex", None, 1, "claude"]})
+        )
+        assert load_fallback_chains(str(state_path))["implement"] == ["codex", "claude"]
+
+
+# ---------------------------------------------------------------------------
+# next_agent
+# ---------------------------------------------------------------------------
+
+
+class TestNextAgent:
+    def test_progresses_through_chain(self):
+        assert next_agent("implement", "claude", []) == "codex"
+        assert next_agent("implement", "codex", []) == "gemini"
+
+    def test_chain_exhausted_returns_none(self):
+        assert next_agent("implement", "gemini", []) is None
+
+    def test_excluded_agents_skipped(self):
+        assert next_agent("implement", "claude", ["codex"]) == "gemini"
+
+    def test_unknown_current_starts_from_head(self):
+        assert next_agent("implement", None, []) == "claude"
+        assert next_agent("implement", "stranger", []) == "claude"
+
+    def test_unknown_task_type(self):
+        assert next_agent("nonsense", "claude", []) is None
+
+    def test_custom_chains(self):
+        chains = {"implement": ["alice", "bob", "carol"]}
+        assert next_agent("implement", "alice", [], chains) == "bob"
+        assert next_agent("implement", "bob", [], chains) == "carol"
+        assert next_agent("implement", "carol", [], chains) is None
+
+    def test_excluded_includes_current(self):
+        # current agent is already in excluded — should still walk forward
+        assert next_agent("implement", "claude", ["claude"]) == "codex"
+
+
+# ---------------------------------------------------------------------------
+# default_agent_for_role
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultAgentForRole:
+    def test_resolves_implementer_to_claude(self):
+        pane_map = {
+            "implementer": "%100",
+            "claude": "%100",
+            "reviewer": "%101",
+            "codex": "%101",
+        }
+        assert default_agent_for_role("implementer", pane_map) == "claude"
+        assert default_agent_for_role("reviewer", pane_map) == "codex"
+
+    def test_unknown_role_returns_none(self):
+        pane_map = {"implementer": "%100", "claude": "%100"}
+        assert default_agent_for_role("unknown", pane_map) is None
+
+    def test_role_with_no_agent_partner_returns_none(self):
+        pane_map = {"implementer": "%999"}  # no agent maps to this pane
+        assert default_agent_for_role("implementer", pane_map) is None
+
+    def test_empty_pane_map(self):
+        assert default_agent_for_role("implementer", {}) is None

--- a/tests/unit/test_server_fallback.py
+++ b/tests/unit/test_server_fallback.py
@@ -1,0 +1,221 @@
+"""Server-side integration tests for the rate-limit auto-fallback (Issue #81)."""
+import json
+
+from fastapi.testclient import TestClient
+
+from agent_crew.queue import TaskQueue
+from agent_crew.server import create_app
+
+
+def _task_payload(task_id="t1", task_type="implement", description="do work"):
+    return {
+        "task_id": task_id,
+        "task_type": task_type,
+        "description": description,
+        "branch": "main",
+        "priority": 3,
+        "context": {},
+        "project": "",
+    }
+
+
+def _result(task_id, status="failed", summary="rate limit reached", findings=None):
+    return {
+        "task_id": task_id,
+        "status": status,
+        "summary": summary,
+        "verdict": None,
+        "findings": findings or [],
+        "pr_number": None,
+    }
+
+
+def _make_app(tmp_db, *, push_calls, panes=None, **kwargs):
+    panes = panes or {
+        "implementer": "%C", "claude": "%C",
+        "reviewer": "%X",    "codex":  "%X",
+        "tester": "%G",      "gemini": "%G",
+    }
+
+    def push(pane_id, text):
+        push_calls.append((pane_id, text))
+
+    return create_app(
+        db_path=tmp_db,
+        pane_map=panes,
+        port=8200,
+        push_fn=push,
+        watchdog_disabled=True,
+        **kwargs,
+    )
+
+
+# U-FB01: rate-limit hit on implementer (claude) reroutes the same task to codex.
+def test_u_fb01_rate_limit_reroutes_implement_to_next_agent(tmp_db):
+    push_calls: list = []
+    app = _make_app(tmp_db, push_calls=push_calls)
+
+    with TestClient(app) as client:
+        client.post("/tasks", json=_task_payload("impl-1"))
+        # Original push went to claude pane (%C).
+        assert any(pane == "%C" for pane, _ in push_calls)
+
+        # Implementer reports rate-limit failure.
+        client.post("/tasks/impl-1/result", json=_result("impl-1"))
+
+    # Fallback should have enqueued a new implement task (or it may be pushed already).
+    rows = TaskQueue(tmp_db).list_all_with_status()
+    fallback = [r for r in rows if r["task_id"].startswith("fallback-impl-1-")]
+    assert len(fallback) == 1
+    fallback_task = TaskQueue(tmp_db).list_tasks()
+    fb_task = next(t for t in fallback_task if t.task_id.startswith("fallback-impl-1-"))
+    assert fb_task.context["agent_override"] == "codex"
+    assert fb_task.context["fallback_excluded"] == ["claude"]
+    # The fallback push went to codex pane (%X).
+    fallback_push = [c for c in push_calls if c[0] == "%X"]
+    assert len(fallback_push) == 1
+
+
+# U-FB02: rate-limit on the fallback agent (codex) cascades to gemini.
+def test_u_fb02_rate_limit_chain_progresses(tmp_db):
+    push_calls: list = []
+    app = _make_app(tmp_db, push_calls=push_calls)
+
+    with TestClient(app) as client:
+        client.post("/tasks", json=_task_payload("impl-2"))
+        client.post("/tasks/impl-2/result", json=_result("impl-2", summary="usage limit"))
+        # Find the fallback task id and fail it too.
+        fb_task = next(
+            t for t in TaskQueue(tmp_db).list_tasks()
+            if t.task_id.startswith("fallback-impl-2-")
+        )
+        client.post(f"/tasks/{fb_task.task_id}/result", json=_result(fb_task.task_id, summary="quota exceeded"))
+
+    # Second fallback should target gemini, with both claude and codex excluded.
+    cascading = [
+        t for t in TaskQueue(tmp_db).list_tasks()
+        if t.task_id.startswith("fallback-")
+    ]
+    # Two fallback tasks exist: claude→codex, then codex→gemini.
+    assert len(cascading) == 2
+    second = next(t for t in cascading if t.context.get("agent_override") == "gemini")
+    assert sorted(second.context["fallback_excluded"]) == ["claude", "codex"]
+
+
+# U-FB03: chain exhaustion creates an escalation gate; no further fallback enqueued.
+def test_u_fb03_chain_exhaustion_creates_escalation_gate(tmp_db):
+    push_calls: list = []
+    notify_calls: list = []
+
+    # Patch notify_telegram to capture the call without going to the network.
+    import agent_crew.server as server_mod
+    original_notify = server_mod.notify_telegram
+    server_mod.notify_telegram = lambda msg, **kw: (notify_calls.append(msg), True)[1]
+    try:
+        app = _make_app(tmp_db, push_calls=push_calls)
+        with TestClient(app) as client:
+            client.post("/tasks", json=_task_payload("impl-3"))
+            client.post("/tasks/impl-3/result", json=_result("impl-3", summary="rate limit"))
+            fb1 = next(
+                t for t in TaskQueue(tmp_db).list_tasks()
+                if t.task_id.startswith("fallback-impl-3-")
+            )
+            client.post(f"/tasks/{fb1.task_id}/result", json=_result(fb1.task_id, summary="quota exceeded"))
+            fb2 = next(
+                t for t in TaskQueue(tmp_db).list_tasks()
+                if t.task_id.startswith("fallback-") and t.task_id != fb1.task_id
+            )
+            client.post(f"/tasks/{fb2.task_id}/result", json=_result(fb2.task_id, summary="usage limit"))
+    finally:
+        server_mod.notify_telegram = original_notify
+
+    # No 4th fallback enqueued.
+    fallback_tasks = [
+        t for t in TaskQueue(tmp_db).list_tasks()
+        if t.task_id.startswith("fallback-")
+    ]
+    assert len(fallback_tasks) == 2
+    # Escalation gate created.
+    gates = TaskQueue(tmp_db).list_gates()
+    escalations = [g for g in gates if g.type == "escalation"]
+    assert len(escalations) == 1
+    assert "impl-3" in escalations[0].message or "rate-limit" in escalations[0].message
+    # Notify helper was called.
+    assert notify_calls and "rate-limit" in notify_calls[0].lower()
+
+
+# U-FB04: non-rate-limit failure falls through to the auto-retry path
+# (not the fallback path) — fallback must NOT trigger.
+def test_u_fb04_non_rate_limit_failure_skips_fallback(tmp_db):
+    push_calls: list = []
+    app = _make_app(tmp_db, push_calls=push_calls)
+
+    with TestClient(app) as client:
+        client.post("/tasks", json=_task_payload("impl-4"))
+        client.post(
+            "/tasks/impl-4/result",
+            json=_result(
+                "impl-4",
+                summary="syntax error in foo.py",
+                findings=["unexpected indent"],
+            ),
+        )
+
+    # Fallback should NOT have enqueued a new task.
+    fallback_tasks = [
+        t for t in TaskQueue(tmp_db).list_tasks()
+        if t.task_id.startswith("fallback-")
+    ]
+    assert fallback_tasks == []
+    # But the existing auto-retry path should have produced a retry task.
+    retry_tasks = [
+        t for t in TaskQueue(tmp_db).list_tasks()
+        if t.task_id.startswith("retry-")
+    ]
+    assert len(retry_tasks) == 1
+
+
+# U-FB05: AGENT_CREW_FALLBACK_DISABLED forces the legacy retry path.
+def test_u_fb05_disabled_via_env(tmp_db, monkeypatch):
+    monkeypatch.setenv("AGENT_CREW_FALLBACK_DISABLED", "1")
+    push_calls: list = []
+    app = _make_app(tmp_db, push_calls=push_calls)
+
+    with TestClient(app) as client:
+        client.post("/tasks", json=_task_payload("impl-5"))
+        client.post("/tasks/impl-5/result", json=_result("impl-5", summary="rate limit"))
+
+    # No fallback path was taken; the existing retry path was used instead.
+    fallback_tasks = [
+        t for t in TaskQueue(tmp_db).list_tasks()
+        if t.task_id.startswith("fallback-")
+    ]
+    assert fallback_tasks == []
+    retry_tasks = [
+        t for t in TaskQueue(tmp_db).list_tasks()
+        if t.task_id.startswith("retry-")
+    ]
+    assert len(retry_tasks) == 1
+
+
+# U-FB06: per-project chain override (~/.agent_crew/<project>/fallback_chains.json)
+# changes the next-agent decision.
+def test_u_fb06_chain_override_respected(tmp_db, tmp_path):
+    state_path = tmp_path / "state.json"
+    state_path.write_text("{}")
+    override = tmp_path / "fallback_chains.json"
+    override.write_text(json.dumps({"implement": ["claude", "gemini", "codex"]}))
+
+    push_calls: list = []
+    app = _make_app(tmp_db, push_calls=push_calls, state_path=str(state_path))
+
+    with TestClient(app) as client:
+        client.post("/tasks", json=_task_payload("impl-6"))
+        client.post("/tasks/impl-6/result", json=_result("impl-6", summary="rate limit"))
+
+    # Override chain: claude → gemini (not codex).
+    fb_task = next(
+        t for t in TaskQueue(tmp_db).list_tasks()
+        if t.task_id.startswith("fallback-impl-6-")
+    )
+    assert fb_task.context["agent_override"] == "gemini"


### PR DESCRIPTION
## Summary

Closes #81. When an agent provider hits its rate limit, today's single-role retry just rebroadcasts the same problem to the same pane and the pipeline stalls. This PR reroutes such failures to the next agent in a configurable chain, and only escalates once the whole chain is exhausted.

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| claude impl returns \`status=failed\` with \"rate limit\" | retried on claude until MAX_RETRIES, still stuck | rerouted to codex (and from there to gemini if codex also fails) |
| Chain exhausted across all agents | task sits failed, no signal to operator | \`GateRequest type=escalation\` opened + best-effort \`notify_telegram\` fired |
| \`status=failed\` for any non-rate-limit reason | unchanged — \`_auto_retry_failed_task\` runs | unchanged — fallback path returns False, legacy retry runs |
| Operator wants legacy behavior | n/a | \`AGENT_CREW_FALLBACK_DISABLED=1\` flips it off |

## Files

- **\`src/agent_crew/fallback.py\`** (new) — five pure helpers: \`is_rate_limit_error\`, \`has_rate_limit_signal\`, \`load_fallback_chains\` (reads \`<state_dir>/fallback_chains.json\`, merges over defaults), \`next_agent\`, \`default_agent_for_role\` (reverse-lookup agent for a role via pane_map). No FastAPI / SQLite touch — testable as plain functions.
- **\`src/agent_crew/server.py\`** — \`_auto_fallback_failed_task\` invoked before \`_auto_retry_failed_task\` in the result handler. On match: enqueue new task with \`context.agent_override\` + \`context.fallback_excluded\` so the existing push code (which already supports \`agent_override\`) routes to the right pane. On exhaustion: gate + notify. \`create_app(...)\` gains \`fallback_disabled\` parameter with env fallback.

## Tests

- \`tests/unit/test_fallback.py\` — 31 tests cover pattern detection across every provider style we run, chain loading with overrides, next-agent walking with exclusion, and pane-map reverse lookup.
- \`tests/unit/test_server_fallback.py\` — 6 \`TestClient\`-driven scenarios:
  - U-FB01: claude rate-limit → codex pane receives the rerouted task
  - U-FB02: cascade claude → codex → gemini
  - U-FB03: chain exhaustion → escalation gate + notify_telegram called
  - U-FB04: non-rate-limit failure leaves the legacy retry path alone
  - U-FB05: \`AGENT_CREW_FALLBACK_DISABLED\` disables the new path
  - U-FB06: per-project \`fallback_chains.json\` override changes the routing decision

Full suite: 221/224 passing — the 3 failing \`test_u_c20/21/22\` are pre-existing (#88), unrelated to this change.

## Config knobs (new)

| Name | Default | Purpose |
|------|---------|---------|
| \`AGENT_CREW_FALLBACK_DISABLED\` | _(unset)_ | \`1\`/\`true\`/\`yes\` reverts to legacy retry-only path |
| \`<state_dir>/fallback_chains.json\` | _(none)_ | Per-project override of the default chains |

## Test plan

- [x] \`pytest tests/unit/test_fallback.py tests/unit/test_server_fallback.py -v\`
- [ ] After merge: smoke against the running agent_crew server (port 8102) by injecting a synthetic \`status=failed summary=\"rate limit\"\` POST and watching server.log for the reroute log line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)