### PR TITLE
fix(#84): drop sticky busy markers from _pane_is_busy

### DIFF
--- a/src/agent_crew/server.py
+++ b/src/agent_crew/server.py
@@ -52,31 +52,28 @@ def _pane_alive_for_push(pane_id: str) -> bool:
 def _pane_is_busy(pane_id: str) -> bool:
     """Return True if the pane shows the agent is actively processing.
 
-    Looks for indicators that the underlying CLI (Claude Code, codex, gemini)
-    is mid-thought:
-    - ``esc to interrupt`` — Claude/Codex footer while a tool/agent is running
-    - ``Crunched`` / ``Compacting`` — Claude active state lines
-    - ``Working`` / ``Thinking`` — alternate active states
-    - ``✻`` / ``✽`` — Claude spinner glyph
+    The reliable signal across Claude Code / Codex / Gemini CLIs is the
+    ``esc to interrupt`` footer string. It only appears while the agent is
+    actively running a tool or generating output; the moment the agent goes
+    idle, the footer reverts to a non-interruptible variant
+    (e.g. ``⏵⏵ bypass permissions``).
 
-    A False return means the pane is sitting idle (prompt visible, no spinner).
+    Earlier versions also matched ``✻`` / ``✽`` spinner glyphs and the bare
+    words ``Crunched`` / ``Working`` / ``Thinking``, but Claude leaves
+    *past-tense* status lines on screen after a tool finishes —
+    ``✻ Cogitated for 5m 16s``, ``Crunched for 30s`` — which kept this
+    function returning True forever. That broke the watchdog (issue #84):
+    last_activity_at was bumped on every tick, so the idle clock never
+    started and reminders/timeouts never fired.
+
+    A False return means the pane is sitting idle (no agent footer banner).
     Used by the watchdog to decide whether to bump last_activity_at.
     """
     r = subprocess.run(
         ["tmux", "capture-pane", "-p", "-t", pane_id],
         capture_output=True, text=True,
     )
-    out = r.stdout
-    busy_markers = (
-        "esc to interrupt",
-        "Crunched",
-        "Compacting",
-        "Working",
-        "Thinking",
-        "✻",
-        "✽",
-    )
-    return any(marker in out for marker in busy_markers)
+    return "esc to interrupt" in r.stdout
 
 
 def _pane_has_task(pane_id: str) -> bool:

--- a/tests/unit/test_pane_is_busy.py
+++ b/tests/unit/test_pane_is_busy.py
@@ -1,0 +1,80 @@
+"""Regression tests for _pane_is_busy (Issue #84).
+
+The watchdog (#76 / PR #77) relies on _pane_is_busy to decide whether to
+bump last_activity_at. When the function over-reports busy, the idle clock
+never starts and reminders / timeouts never fire — exactly the failure mode
+documented in #84.
+"""
+from unittest.mock import MagicMock, patch
+
+from agent_crew.server import _pane_is_busy
+
+
+def _captured(text: str) -> MagicMock:
+    """Build a MagicMock whose stdout matches what tmux capture-pane returns."""
+    m = MagicMock()
+    m.stdout = text
+    m.returncode = 0
+    return m
+
+
+def test_active_pane_with_esc_to_interrupt_is_busy():
+    pane = (
+        "✻ Cogitating… (12s · ↓ 1.2k tokens)\n"
+        "ℹ Working through the diff…\n"
+        "─────────\n"
+        "❯ \n"
+        "─────────\n"
+        " ⏵⏵ bypass permissions on (shift+tab to cycle) · esc to interrupt\n"
+    )
+    with patch("agent_crew.server.subprocess.run", return_value=_captured(pane)):
+        assert _pane_is_busy("%999") is True
+
+
+def test_idle_pane_with_past_tense_glyph_is_not_busy():
+    """Issue #84 root cause — ``✻ Cogitated for 5m 16s`` persists in scrollback
+    after work finishes. The old implementation matched on ``✻`` literally and
+    returned True forever; the watchdog never fired."""
+    pane = (
+        "✻ Cogitated for 5m 16s\n"
+        "─────────\n"
+        "❯ \n"
+        "─────────\n"
+        " ⏵⏵ bypass permissions on (shift+tab to cycle)\n"
+    )
+    with patch("agent_crew.server.subprocess.run", return_value=_captured(pane)):
+        assert _pane_is_busy("%999") is False
+
+
+def test_idle_pane_with_past_tense_crunched_is_not_busy():
+    """Same root cause via the ``Crunched`` literal (e.g. ``Crunched for 30s``)."""
+    pane = (
+        "✻ Crunched for 30s\n"
+        "❯ \n"
+        " ⏵⏵ bypass permissions on (shift+tab to cycle)\n"
+    )
+    with patch("agent_crew.server.subprocess.run", return_value=_captured(pane)):
+        assert _pane_is_busy("%999") is False
+
+
+def test_completely_blank_pane_is_not_busy():
+    with patch("agent_crew.server.subprocess.run", return_value=_captured("\n")):
+        assert _pane_is_busy("%999") is False
+
+
+def test_codex_active_state_is_busy():
+    """Codex shows ``Working (12s • esc to interrupt)`` mid-task."""
+    pane = (
+        "› Summarize recent commits\n"
+        "◦ Working (12s • esc to interrupt)\n"
+        "  gpt-5.4-mini medium · ~/.agent_crew/worktrees/agent_crew/codex\n"
+    )
+    with patch("agent_crew.server.subprocess.run", return_value=_captured(pane)):
+        assert _pane_is_busy("%999") is True
+
+
+def test_subprocess_failure_returns_false():
+    """A broken tmux call must not crash the watchdog tick."""
+    failing = MagicMock(stdout="", returncode=1)
+    with patch("agent_crew.server.subprocess.run", return_value=failing):
+        assert _pane_is_busy("%999") is False


### PR DESCRIPTION
## Summary

Closes #84. The watchdog (#76 / PR #77) never fired a single REMINDER or TIMEOUT in practice because \`_pane_is_busy\` matched on \`✻\` and bare verbs like \`Crunched\` / \`Working\`, which Claude Code leaves on screen as **past-tense** status lines after a tool finishes. Every watchdog tick re-read the same scrollback, decided the pane was busy, and bumped \`last_activity_at\` — the idle clock literally never started.

This was confirmed against the live agent_crew server.log on port 8102: 0 REMINDER / TIMEOUT entries during a 9-minute idle pane during the #79 implementation loop.

## Fix

Use a single, unambiguous signal: \`esc to interrupt\`. It is present in the active footer of Claude / Codex / Gemini exclusively while the agent is running, and disappears the moment control returns. No past-tense form, no scrollback contamination.

## Tests

- \`tests/unit/test_pane_is_busy.py\` (new) — 6 regression scenarios:
  - active claude with \`esc to interrupt\` → True
  - **idle claude with \`✻ Cogitated for 5m 16s\` in scrollback → False** (the #84 case)
  - **idle claude with \`Crunched for 30s\` → False**
  - blank pane → False
  - active codex (\`Working (12s • esc to interrupt)\`) → True
  - tmux subprocess failure → False
- Existing watchdog suite (8 tests) unchanged and still passing — they inject \`pane_busy_fn\` so they already exercise the contract synthetically; this PR just makes the production probe match it.

Full suite: 248/251 passing — the 3 failing test_cli are pre-existing (#88), unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)