### PR TITLE
fix(#84): replace banner-text matching with pane-content diff

### DIFF
--- a/src/agent_crew/server.py
+++ b/src/agent_crew/server.py
@@ -49,31 +49,54 @@ def _pane_alive_for_push(pane_id: str) -> bool:
     return r.returncode == 0
 
 
+# Per-pane snapshot of the previous capture, keyed by pane_id. Used by the
+# default pane-busy probe to decide "did anything change since the last
+# tick?". Tests inject their own busy_fn so this dict is only touched by the
+# default path; pollution between tests is handled by `_reset_pane_busy_cache`.
+_PANE_BUSY_LAST: dict[str, str] = {}
+
+
+def _reset_pane_busy_cache() -> None:
+    """Clear the per-pane diff cache. Test-only entry point."""
+    _PANE_BUSY_LAST.clear()
+
+
 def _pane_is_busy(pane_id: str) -> bool:
-    """Return True if the pane shows the agent is actively processing.
+    """Return True if the pane content changed since the previous call.
 
-    The reliable signal across Claude Code / Codex / Gemini CLIs is the
-    ``esc to interrupt`` footer string. It only appears while the agent is
-    actively running a tool or generating output; the moment the agent goes
-    idle, the footer reverts to a non-interruptible variant
-    (e.g. ``⏵⏵ bypass permissions``).
+    Pure content diff. Independent of any per-CLI banner text — Claude Code,
+    codex, and gemini all change `tmux capture-pane -p` output as work
+    progresses (token counters tick, spinner glyphs animate, output streams
+    in). A pane that is genuinely idle produces an identical capture across
+    consecutive calls.
 
-    Earlier versions also matched ``✻`` / ``✽`` spinner glyphs and the bare
-    words ``Crunched`` / ``Working`` / ``Thinking``, but Claude leaves
-    *past-tense* status lines on screen after a tool finishes —
-    ``✻ Cogitated for 5m 16s``, ``Crunched for 30s`` — which kept this
-    function returning True forever. That broke the watchdog (issue #84):
-    last_activity_at was bumped on every tick, so the idle clock never
-    started and reminders/timeouts never fired.
+    Earlier versions matched on banner strings (``✻``, ``Crunched``,
+    ``Working``, ``Thinking``, ``esc to interrupt``). Both approaches are
+    brittle: glyph forms persist as past-tense scrollback (the original #84
+    failure mode) and the canonical ``esc to interrupt`` is one Claude UI
+    refresh away from being renamed. Comparing whole captures sidesteps the
+    text dependency entirely.
 
-    A False return means the pane is sitting idle (no agent footer banner).
-    Used by the watchdog to decide whether to bump last_activity_at.
+    Edge cases:
+    - First call for a pane has no prior snapshot → returns False (idle).
+      That's safe because activity is freshly bumped at task enqueue, so the
+      idle clock is well below any threshold.
+    - tmux capture-pane failing returns False — the watchdog must never
+      crash on a transient pane-probe error.
     """
-    r = subprocess.run(
-        ["tmux", "capture-pane", "-p", "-t", pane_id],
-        capture_output=True, text=True,
-    )
-    return "esc to interrupt" in r.stdout
+    try:
+        r = subprocess.run(
+            ["tmux", "capture-pane", "-p", "-t", pane_id],
+            capture_output=True, text=True,
+        )
+    except Exception:
+        return False
+    if r.returncode != 0:
+        return False
+    current = r.stdout
+    prev = _PANE_BUSY_LAST.get(pane_id)
+    _PANE_BUSY_LAST[pane_id] = current
+    return prev is not None and current != prev
 
 
 def _pane_has_task(pane_id: str) -> bool:

--- a/tests/unit/test_pane_is_busy.py
+++ b/tests/unit/test_pane_is_busy.py
@@ -1,80 +1,120 @@
-"""Regression tests for _pane_is_busy (Issue #84).
+"""Regression tests for `_pane_is_busy` (Issue #84 — diff-based detection).
 
-The watchdog (#76 / PR #77) relies on _pane_is_busy to decide whether to
-bump last_activity_at. When the function over-reports busy, the idle clock
-never starts and reminders / timeouts never fire — exactly the failure mode
-documented in #84.
+The default busy-probe used to scrape the pane for specific banner strings
+(``✻``, ``Crunched``, ``esc to interrupt``). Both versions broke when the
+banner text changed (past-tense scrollback or future Claude UI updates).
+The current implementation compares pane content across consecutive calls,
+which is text-agnostic.
+
+These tests pin that contract: identical captures → idle, different
+captures → busy, with the cache deterministically reset between cases.
 """
 from unittest.mock import MagicMock, patch
 
-from agent_crew.server import _pane_is_busy
+import pytest
+
+from agent_crew.server import _pane_is_busy, _reset_pane_busy_cache
 
 
-def _captured(text: str) -> MagicMock:
-    """Build a MagicMock whose stdout matches what tmux capture-pane returns."""
+@pytest.fixture(autouse=True)
+def _isolate_busy_cache():
+    _reset_pane_busy_cache()
+    yield
+    _reset_pane_busy_cache()
+
+
+def _captured(text: str, *, returncode: int = 0) -> MagicMock:
     m = MagicMock()
     m.stdout = text
-    m.returncode = 0
+    m.returncode = returncode
     return m
 
 
-def test_active_pane_with_esc_to_interrupt_is_busy():
-    pane = (
-        "✻ Cogitating… (12s · ↓ 1.2k tokens)\n"
-        "ℹ Working through the diff…\n"
-        "─────────\n"
-        "❯ \n"
-        "─────────\n"
-        " ⏵⏵ bypass permissions on (shift+tab to cycle) · esc to interrupt\n"
+def test_first_call_for_pane_returns_false():
+    """No prior snapshot → assume idle (activity is fresh from task enqueue)."""
+    cap = _captured("anything\n")
+    with patch("agent_crew.server.subprocess.run", return_value=cap):
+        assert _pane_is_busy("%999") is False
+
+
+def test_unchanged_capture_returns_false():
+    """Two identical captures back-to-back → pane is idle."""
+    cap = _captured("the agent finished — same content twice\n")
+    with patch("agent_crew.server.subprocess.run", return_value=cap):
+        assert _pane_is_busy("%999") is False  # priming
+        assert _pane_is_busy("%999") is False
+
+
+def test_changed_capture_returns_true():
+    """When the second capture differs from the first → pane is busy."""
+    captures = iter(
+        [
+            _captured("step 1: thinking…\n"),
+            _captured("step 1: thinking…\nstep 2: writing code\n"),
+        ]
     )
-    with patch("agent_crew.server.subprocess.run", return_value=_captured(pane)):
+
+    def fake_run(*_args, **_kwargs):
+        return next(captures)
+
+    with patch("agent_crew.server.subprocess.run", side_effect=fake_run):
+        assert _pane_is_busy("%999") is False  # priming
         assert _pane_is_busy("%999") is True
 
 
-def test_idle_pane_with_past_tense_glyph_is_not_busy():
-    """Issue #84 root cause — ``✻ Cogitated for 5m 16s`` persists in scrollback
-    after work finishes. The old implementation matched on ``✻`` literally and
-    returned True forever; the watchdog never fired."""
-    pane = (
+def test_past_tense_glyph_does_not_trip_busy():
+    """Issue #84 root cause — Claude leaves ``✻ Cogitated for 5m 16s`` in
+    scrollback after work finishes. As long as the pane content is stable,
+    the diff probe must report idle."""
+    cap = _captured(
         "✻ Cogitated for 5m 16s\n"
-        "─────────\n"
-        "❯ \n"
-        "─────────\n"
-        " ⏵⏵ bypass permissions on (shift+tab to cycle)\n"
-    )
-    with patch("agent_crew.server.subprocess.run", return_value=_captured(pane)):
-        assert _pane_is_busy("%999") is False
-
-
-def test_idle_pane_with_past_tense_crunched_is_not_busy():
-    """Same root cause via the ``Crunched`` literal (e.g. ``Crunched for 30s``)."""
-    pane = (
-        "✻ Crunched for 30s\n"
         "❯ \n"
         " ⏵⏵ bypass permissions on (shift+tab to cycle)\n"
     )
-    with patch("agent_crew.server.subprocess.run", return_value=_captured(pane)):
+    with patch("agent_crew.server.subprocess.run", return_value=cap):
+        # Three ticks at the watchdog interval, all reading the same scrollback
+        # → pane stays idle even with the past-tense glyph visible.
+        assert _pane_is_busy("%999") is False
+        assert _pane_is_busy("%999") is False
         assert _pane_is_busy("%999") is False
 
 
-def test_completely_blank_pane_is_not_busy():
-    with patch("agent_crew.server.subprocess.run", return_value=_captured("\n")):
-        assert _pane_is_busy("%999") is False
+def test_each_pane_tracked_independently():
+    """One pane changing does not flip another pane's idle state."""
+    pane_a_cap = _captured("a-1\n")
+    pane_b_caps = iter([_captured("b-1\n"), _captured("b-2\n")])
 
+    def fake_run(args, **_kwargs):
+        # args = ['tmux', 'capture-pane', '-p', '-t', '%pane']
+        target = args[-1]
+        if target == "%A":
+            return pane_a_cap
+        return next(pane_b_caps)
 
-def test_codex_active_state_is_busy():
-    """Codex shows ``Working (12s • esc to interrupt)`` mid-task."""
-    pane = (
-        "› Summarize recent commits\n"
-        "◦ Working (12s • esc to interrupt)\n"
-        "  gpt-5.4-mini medium · ~/.agent_crew/worktrees/agent_crew/codex\n"
-    )
-    with patch("agent_crew.server.subprocess.run", return_value=_captured(pane)):
-        assert _pane_is_busy("%999") is True
+    with patch("agent_crew.server.subprocess.run", side_effect=fake_run):
+        assert _pane_is_busy("%A") is False  # priming A
+        assert _pane_is_busy("%B") is False  # priming B
+        assert _pane_is_busy("%A") is False  # A unchanged
+        assert _pane_is_busy("%B") is True   # B changed b-1 → b-2
 
 
 def test_subprocess_failure_returns_false():
-    """A broken tmux call must not crash the watchdog tick."""
-    failing = MagicMock(stdout="", returncode=1)
+    """tmux failure must not crash the watchdog tick."""
+    failing = _captured("", returncode=1)
     with patch("agent_crew.server.subprocess.run", return_value=failing):
+        assert _pane_is_busy("%999") is False
+
+
+def test_subprocess_exception_returns_false():
+    """A real exception (e.g. tmux binary missing) must also be swallowed."""
+    with patch("agent_crew.server.subprocess.run", side_effect=FileNotFoundError("tmux")):
+        assert _pane_is_busy("%999") is False
+
+
+def test_reset_cache_makes_next_call_act_like_first():
+    cap_a = _captured("a\n")
+    with patch("agent_crew.server.subprocess.run", return_value=cap_a):
+        assert _pane_is_busy("%999") is False  # priming
+        _reset_pane_busy_cache()
+        # After reset the next call has no prior snapshot again.
         assert _pane_is_busy("%999") is False


### PR DESCRIPTION
## Summary

Re-closes #84. PR #91 fixed the immediate symptom by switching the busy probe to \`esc to interrupt\` matching, but the dependency on a Claude UI string is just as brittle as the original — any banner rename or different agent CLI breaks the watchdog again.

This PR drops the text dependency entirely. Cache the previous capture per pane, compare. Identical → idle. Different → busy. Works against any CLI that shows token counters / spinner animations / streaming output, which is all of them.

## Implementation

- \`_PANE_BUSY_LAST: dict[str, str]\` per-pane cache.
- \`_pane_is_busy\` returns \`prev is not None and current != prev\`.
- First call returns False (no prior). Safe — activity is freshly bumped at task enqueue, idle clock is well under any threshold.
- Both subprocess failure (returncode != 0) and unhandled exceptions return False, so the watchdog can never crash on a transient pane probe.
- \`_reset_pane_busy_cache\` exposed as a test-only entry point.

## Tests

\`tests/unit/test_pane_is_busy.py\` rewritten — 8 cases:

1. First call for a new pane → False (no prior)
2. Two identical captures → False (idle)
3. Capture changed between calls → True (busy)
4. Past-tense \`✻ Cogitated for 5m 16s\` glyph in scrollback, captured 3× unchanged → False (the original #84 case)
5. Two panes tracked independently — one stable, one changing
6. tmux \`returncode != 0\` → False
7. tmux raises FileNotFoundError → False
8. After \`_reset_pane_busy_cache\`, next call again has no prior

The 8 watchdog suite tests still pass — they inject their own busy_fn. Full unit suite: 250/253 passing — the 3 \`test_cli\` failures are pre-existing (#88), unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)