### PR TITLE
fix(#85): stream-timeout recovery — reminder triage + watchdog→fallback

### DIFF
--- a/src/agent_crew/fallback.py
+++ b/src/agent_crew/fallback.py
@@ -15,9 +15,12 @@ import os
 import re
 from typing import Any, Optional
 
-# Patterns surfaced by alpha_engine #756 / #759 across the three providers we
-# routinely run. Compiled case-insensitively. Add new ones here when an
-# additional provider message starts leaking through.
+# Failover signals: any failure summary that means "this agent can't make
+# forward progress, try a different one." Rate-limit messages are the bulk
+# of these (alpha_engine #756 / #759). Watchdog-timeout summaries (#85)
+# also qualify — a stuck pane after API stream-timeout recovers fastest by
+# routing the task to a fresh agent rather than retrying the same one.
+# Compiled case-insensitively.
 _RATE_LIMIT_PATTERNS: tuple[str, ...] = (
     r"usage limit",          # codex / openai
     r"rate[- ]?limit",       # claude / generic
@@ -27,6 +30,11 @@ _RATE_LIMIT_PATTERNS: tuple[str, ...] = (
     r"too many requests",    # http 429
     r"resource[_ ]exhausted",  # google "resource_exhausted"
     r"insufficient[_ ]quota",  # openai
+    r"stream[ _]idle[ _]timeout",  # claude code "API Stream idle timeout"
+    r"stream[ _]timeout",          # generic streaming-API timeout
+    r"watchdog timeout",           # agent_crew force_fail summary (#85)
+    r"pane idle",                  # alternate watchdog phrasing
+    r"partial response",           # claude code partial-response state
 )
 
 _RATE_LIMIT_RE = re.compile("|".join(_RATE_LIMIT_PATTERNS), re.IGNORECASE)

--- a/src/agent_crew/server.py
+++ b/src/agent_crew/server.py
@@ -178,22 +178,39 @@ def _format_reminder_message(task_id: str, port: int, idle_seconds: float) -> st
     """Watchdog nudge: agent has been silent past the heartbeat threshold.
 
     Includes the canonical POST template so the agent can resolve the task in
-    one paste even if the original block scrolled out of context.
+    one paste even if the original block scrolled out of context. Also covers
+    the API stream-timeout recovery path (issue #85): after a transient
+    network failure the agent CLI may drop back to the prompt with no result
+    posted; this reminder is the canonical handoff to either retry or fail
+    out cleanly.
     """
     return (
         f"=== AGENT_CREW REMINDER ===\n"
         f"task_id: {task_id}\n"
-        f"Your assigned task has been silent for {idle_seconds:.0f}s with no\n"
-        f"sign of activity in this pane. The crew stalls until you POST the\n"
-        f"result.\n"
+        f"This pane has been silent for {idle_seconds:.0f}s with no sign of\n"
+        f"activity. The crew stalls until you POST a result for this task.\n"
         f"\n"
-        f"If finished, POST now:\n"
+        f"Pick one of the three paths below. Paste the curl block, edit the\n"
+        f"placeholders, run it.\n"
+        f"\n"
+        f"1) FINISHED — POST status=\"completed\":\n"
         f"  curl -sS -X POST http://127.0.0.1:{port}/tasks/{task_id}/result \\\n"
         f"    -H 'Content-Type: application/json' \\\n"
         f"    -d '{{\"task_id\":\"{task_id}\",\"status\":\"completed\","
         f"\"summary\":\"...\",\"verdict\":null,\"findings\":[],\"pr_number\":null}}'\n"
         f"\n"
-        f"If still working, ignore this — the next heartbeat will see you busy.\n"
+        f"2) STREAM/API TIMEOUT (partial response, can't recover) — POST\n"
+        f"   status=\"failed\". The fallback policy will reroute this task\n"
+        f"   to the next agent in the chain automatically:\n"
+        f"  curl -sS -X POST http://127.0.0.1:{port}/tasks/{task_id}/result \\\n"
+        f"    -H 'Content-Type: application/json' \\\n"
+        f"    -d '{{\"task_id\":\"{task_id}\",\"status\":\"failed\","
+        f"\"summary\":\"API stream timeout — partial response, no recovery\","
+        f"\"verdict\":null,\"findings\":[],\"pr_number\":null}}'\n"
+        f"\n"
+        f"3) STILL WORKING — ignore this nudge. The next heartbeat will see\n"
+        f"   the pane churning and reset the idle clock. If you can't tell\n"
+        f"   why the pane went quiet, prefer path (2) over silence.\n"
         f"=== END REMINDER ===\n"
     )
 
@@ -449,14 +466,37 @@ def create_app(
                 reminded_task_ids.discard(task_id)
                 actions["timed_out"].append(task_id)
                 if tt is not None:
-                    role = _TYPE_TO_ROLE.get(tt)
-                    if role:
-                        try:
-                            _try_push_next(role)
-                        except Exception:
-                            logger.exception(
-                                f"watchdog: failed to push next task for role {role}"
-                            )
+                    # Reuse the rate-limit fallback hook so a stuck pane gets
+                    # routed to the next agent in the chain instead of just
+                    # falling through to the same role's pending queue. The
+                    # summary above contains "watchdog timeout" / "pane idle"
+                    # patterns that `is_rate_limit_error` recognizes (#85).
+                    synthetic_result = TaskResult(
+                        task_id=task_id,
+                        status="failed",
+                        summary=summary,
+                        verdict=None,
+                        findings=[],
+                        pr_number=None,
+                    )
+                    handled = False
+                    try:
+                        handled = _auto_fallback_failed_task(
+                            task_id, synthetic_result, tt
+                        )
+                    except Exception:
+                        logger.exception(
+                            f"watchdog: fallback hook raised for {task_id}"
+                        )
+                    if not handled:
+                        role = _TYPE_TO_ROLE.get(tt)
+                        if role:
+                            try:
+                                _try_push_next(role)
+                            except Exception:
+                                logger.exception(
+                                    f"watchdog: failed to push next task for role {role}"
+                                )
             elif idle_for >= reminder_seconds and task_id not in reminded_task_ids:
                 try:
                     push_fn(pane_id, _format_reminder_message(task_id, port, idle_for))

--- a/tests/unit/test_stream_timeout_recovery.py
+++ b/tests/unit/test_stream_timeout_recovery.py
@@ -1,0 +1,146 @@
+"""Stream-timeout recovery tests (Issue #85).
+
+Three behaviours pinned here:
+
+1. The watchdog reminder message instructs the agent on three options
+   (complete / failed / keep working), the second of which is the explicit
+   stream-timeout recovery path.
+2. The fallback rate-limit detector recognises watchdog auto-fail summaries
+   so a stuck pane reroutes to the next agent in the chain.
+3. End-to-end: a watchdog timeout produces a `fallback-*` task assigned to
+   the next agent in the chain (not a same-role retry).
+"""
+from fastapi.testclient import TestClient
+
+from agent_crew.fallback import has_rate_limit_signal, is_rate_limit_error
+from agent_crew.queue import TaskQueue
+from agent_crew.server import _format_reminder_message, create_app
+
+
+# ---------------------------------------------------------------------------
+# Reminder-message contract
+# ---------------------------------------------------------------------------
+
+
+class TestReminderMessage:
+    def test_reminder_contains_three_options(self):
+        msg = _format_reminder_message("t-101", port=8200, idle_seconds=400)
+        assert "FINISHED" in msg
+        assert "STREAM/API TIMEOUT" in msg
+        assert "STILL WORKING" in msg
+
+    def test_reminder_includes_failed_status_curl(self):
+        """Path 2 must hand the agent a copy-pasteable POST that submits
+        status="failed" so the fallback policy can pick up the pieces."""
+        msg = _format_reminder_message("t-101", port=8200, idle_seconds=400)
+        assert '"status":"failed"' in msg
+        assert "API stream timeout" in msg
+
+    def test_reminder_includes_completed_status_curl(self):
+        msg = _format_reminder_message("t-101", port=8200, idle_seconds=400)
+        assert '"status":"completed"' in msg
+
+    def test_reminder_carries_task_id_and_port(self):
+        msg = _format_reminder_message("t-uniqueid", port=9123, idle_seconds=315.4)
+        assert "t-uniqueid" in msg
+        assert "9123" in msg
+        # Idle seconds rendered as integer (no fractional)
+        assert "315s" in msg or "315 s" in msg or "315" in msg
+
+
+# ---------------------------------------------------------------------------
+# Fallback pattern recognition
+# ---------------------------------------------------------------------------
+
+
+class TestFalloverPatternsExtended:
+    def test_watchdog_timeout_summary_matches(self):
+        """The summary the watchdog writes when force-failing a stuck task."""
+        summary = "watchdog timeout: pane idle 920s without sign of activity (threshold 900s)"
+        assert is_rate_limit_error(summary) is True
+        assert has_rate_limit_signal(summary, []) is True
+
+    def test_stream_idle_timeout_matches(self):
+        assert is_rate_limit_error("API Stream idle timeout - partial response received") is True
+
+    def test_partial_response_matches(self):
+        assert is_rate_limit_error("partial response, no recovery") is True
+
+    def test_pane_idle_matches(self):
+        assert is_rate_limit_error("pane idle for far too long") is True
+
+    def test_unrelated_summary_still_excluded(self):
+        # Sanity check — the new patterns shouldn't accidentally widen the net.
+        assert is_rate_limit_error("agent posted PR #42") is False
+        assert is_rate_limit_error("merge conflict on requirements.txt") is False
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: watchdog timeout triggers fallback chain
+# ---------------------------------------------------------------------------
+
+
+def _task_payload(task_id="t1", task_type="implement"):
+    return {
+        "task_id": task_id,
+        "task_type": task_type,
+        "description": "do work",
+        "branch": "main",
+        "priority": 3,
+        "context": {},
+        "project": "",
+    }
+
+
+class _Idle:
+    """pane_busy_fn that always reports idle — forces watchdog to time out."""
+
+    def __call__(self, pane_id: str) -> bool:
+        return False
+
+
+class _Push:
+    def __init__(self):
+        self.calls: list = []
+
+    def __call__(self, pane_id, text):
+        self.calls.append((pane_id, text))
+
+
+def test_watchdog_timeout_routes_to_next_agent_via_fallback(tmp_db):
+    """Stuck task auto-failed by the watchdog must produce a `fallback-*`
+    task assigned to the next agent in the chain, not a same-role retry."""
+    push = _Push()
+    panes = {
+        "implementer": "%C", "claude": "%C",
+        "reviewer": "%X", "codex": "%X",
+        "tester": "%G", "gemini": "%G",
+    }
+    app = create_app(
+        db_path=tmp_db,
+        pane_map=panes,
+        port=8200,
+        push_fn=push,
+        pane_busy_fn=_Idle(),
+        reminder_seconds=300.0,
+        timeout_seconds=900.0,
+        watchdog_disabled=True,  # drive ticks manually
+    )
+    with TestClient(app) as client:
+        client.post("/tasks", json=_task_payload("impl-stream"))
+        # Force last_activity_at to a known value, then tick past timeout.
+        TaskQueue(tmp_db).bump_activity("impl-stream", ts=1000.0)
+        result = app.state.watchdog_tick(now=2500.0)
+
+    assert result["timed_out"] == ["impl-stream"]
+
+    # A fallback task should now exist routed to codex (the next agent in
+    # the default implement chain).
+    tasks = TaskQueue(tmp_db).list_tasks()
+    fallback = [t for t in tasks if t.task_id.startswith("fallback-impl-stream-")]
+    assert len(fallback) == 1
+    assert fallback[0].context["agent_override"] == "codex"
+    assert fallback[0].context["fallback_excluded"] == ["claude"]
+    # And no same-role retry was enqueued (the watchdog path doesn't go
+    # through `_auto_retry_failed_task` once the fallback handler returns True).
+    assert [t for t in tasks if t.task_id.startswith("retry-impl-stream-")] == []


### PR DESCRIPTION
## Summary

Closes #85. With #84 v2 in place, the watchdog now correctly sees a stuck pane after an API stream timeout. This PR closes the loop so a stream-timeout failure doesn't just sit failed in the queue — it reroutes to the next agent in the chain automatically.

## Three small changes

1. **Reminder now triages the recovery decision.** \`_format_reminder_message\` is rewritten as a three-option crib sheet (FINISHED / STREAM-TIMEOUT / STILL WORKING), each with its own copy-pasteable POST. The middle path explicitly hands the agent the right \`status=\"failed\"\` payload so the fallback policy can pick up cleanly instead of waiting for the agent to invent a sensible failure summary.

2. **\`is_rate_limit_error\` patterns extended** with five entries that recognise the watchdog auto-fail summary and upstream stream-timeout text: \`stream[ _]idle[ _]timeout\`, \`stream[ _]timeout\`, \`watchdog timeout\`, \`pane idle\`, \`partial response\`. The function is now a misnomer (it's really \"any failover signal\"), but renaming would touch every caller for no behavior change — kept the name and updated the module docstring.

3. **Watchdog auto-fail is now routed through \`_auto_fallback_failed_task\`.** Before falling back to \`_try_push_next\` for the same role, the watchdog invokes the same fallback hook the HTTP \`submit_result\` path uses. The synthesized \`TaskResult\` carries the \"watchdog timeout: pane idle ...\" summary, which matches the new patterns, so a stuck task gets rerouted to the next agent in the chain.

## Tests

\`tests/unit/test_stream_timeout_recovery.py\` — 10 cases:

- Reminder text: contains FINISHED / STREAM-TIMEOUT / STILL WORKING; both \`status=\"completed\"\` and \`status=\"failed\"\` curl bodies present; task_id and port substituted correctly
- Pattern detection: watchdog summary matches; stream-idle, partial-response, pane-idle all match; unrelated failures still excluded
- End-to-end: \`watchdog_tick\` past timeout on an idle pane produces a \`fallback-impl-stream-*\` task with \`agent_override=\"codex\"\` and \`fallback_excluded=[\"claude\"]\`, and no \`retry-*\` task

Full suite: 260/263 passing — the 3 \`test_cli\` failures are pre-existing (#88).

🤖 Generated with [Claude Code](https://claude.com/claude-code)