### PR TITLE
fix(#86): reviewer task pins to live PR head + carries pr_number

### DIFF
--- a/src/agent_crew/server.py
+++ b/src/agent_crew/server.py
@@ -552,9 +552,18 @@ def create_app(
         except asyncio.CancelledError:
             return
 
-    def _auto_enqueue_review(impl_task_id: str) -> None:
+    def _auto_enqueue_review(
+        impl_task_id: str,
+        pr_number: Optional[int] = None,
+    ) -> None:
         """Auto-enqueue a review task when an impl task completes.
-        This ensures review is triggered independently of CLI timeout."""
+        This ensures review is triggered independently of CLI timeout.
+
+        ``pr_number`` is the PR opened by the impl run (if any). It's threaded
+        into both the review task context and the rendered instructions so
+        the reviewer always pins findings to the live PR head commit instead
+        of an earlier round's diff (issue #86).
+        """
         try:
             # Get the original impl task to extract description and branch
             impl_tasks = [t for t in q().list_tasks() if t.task_id == impl_task_id]
@@ -573,6 +582,26 @@ def create_app(
                 )
                 return
 
+            # Build a freshness directive that is unambiguous about reviewing
+            # the live PR HEAD, not a stale local copy or an earlier round.
+            if pr_number is not None:
+                pr_directive = (
+                    f"\n\nFRESHNESS: review PR #{pr_number} at its CURRENT head. "
+                    f"Run `gh pr diff {pr_number}` (and/or "
+                    f"`gh pr view {pr_number} --json commits`) FIRST. Do NOT "
+                    f"reuse line numbers from any earlier review round — they "
+                    f"reference the prior commit. Pin every finding to the "
+                    f"latest commit's file:line."
+                )
+            else:
+                pr_directive = (
+                    f"\n\nFRESHNESS: identify the PR for branch "
+                    f"{impl_task.branch!r} via `gh pr list --head "
+                    f"{impl_task.branch}`, then `gh pr diff <num>` to fetch "
+                    f"the live head before pinning findings. Do NOT review "
+                    f"from a stale local copy."
+                )
+
             # Create review task with same description/branch, reference to impl task.
             # Inherit top-level project from impl task so the cross-project guard works
             # for subsequent hops in the pipeline (review → test).
@@ -584,8 +613,10 @@ def create_app(
                     "1) test_quality — coverage, edge cases, mocks; "
                     "2) code_quality — naming, error handling, SOLID; "
                     "3) business_gap — requirements met, logging, observability."
+                    + pr_directive
                 ),
                 "prev_task_id": impl_task_id,
+                "pr_number": pr_number,
             }
             review_req = TaskRequest(
                 task_id=f"review-{uuid.uuid4().hex[:8]}",
@@ -836,10 +867,12 @@ def create_app(
                 logger.info(f"POST /tasks/{task_id}/result: task failed with status=failed, evaluating fallback/retry")
                 if not _auto_fallback_failed_task(task_id, result, task_type):
                     _auto_retry_failed_task(task_id, result, task_type)
-            # Auto-transition: impl task completed → auto-enqueue review task
+            # Auto-transition: impl task completed → auto-enqueue review task.
+            # Pass through the PR number from the impl result so the reviewer
+            # task description nails down which PR head to diff (#86).
             if task_type == "implement" and result.status == "completed":
                 logger.info(f"POST /tasks/{task_id}/result: impl task completed, auto-enqueueing review")
-                _auto_enqueue_review(task_id)
+                _auto_enqueue_review(task_id, pr_number=result.pr_number)
             # Auto-transition: review task approved → auto-enqueue test task
             if task_type == "review" and result.verdict == "approve":
                 logger.info(f"POST /tasks/{task_id}/result: review task approved, auto-enqueueing test")

--- a/tests/unit/test_review_freshness.py
+++ b/tests/unit/test_review_freshness.py
@@ -1,0 +1,123 @@
+"""Reviewer must be told to read the live PR head, not stale line numbers
+from earlier rounds (Issue #86)."""
+from fastapi.testclient import TestClient
+
+from agent_crew.queue import TaskQueue
+from agent_crew.server import create_app
+
+
+def _impl_payload(task_id="impl-1"):
+    return {
+        "task_id": task_id,
+        "task_type": "implement",
+        "description": "Implement Issue #79 — telegram notify helper",
+        "branch": "agent/agent_crew/claude",
+        "priority": 3,
+        "context": {},
+        "project": "",
+    }
+
+
+def _completed_result(task_id, pr_number=None):
+    return {
+        "task_id": task_id,
+        "status": "completed",
+        "summary": "implementation done",
+        "verdict": None,
+        "findings": [],
+        "pr_number": pr_number,
+    }
+
+
+def _make_app(tmp_db, push_calls):
+    panes = {
+        "implementer": "%C", "claude": "%C",
+        "reviewer": "%X", "codex": "%X",
+        "tester": "%G", "gemini": "%G",
+    }
+
+    def push(pane_id, text):
+        push_calls.append((pane_id, text))
+
+    return create_app(
+        db_path=tmp_db,
+        pane_map=panes,
+        port=8200,
+        push_fn=push,
+        watchdog_disabled=True,
+    )
+
+
+def test_review_task_carries_pr_number_when_impl_posts_one(tmp_db):
+    push_calls: list = []
+    app = _make_app(tmp_db, push_calls)
+    with TestClient(app) as client:
+        client.post("/tasks", json=_impl_payload("impl-86a"))
+        client.post(
+            "/tasks/impl-86a/result",
+            json=_completed_result("impl-86a", pr_number=83),
+        )
+    review = next(
+        t for t in TaskQueue(tmp_db).list_tasks() if t.task_type == "review"
+    )
+    assert review.context["pr_number"] == 83
+
+
+def test_review_instructions_mention_pr_diff_when_pr_known(tmp_db):
+    push_calls: list = []
+    app = _make_app(tmp_db, push_calls)
+    with TestClient(app) as client:
+        client.post("/tasks", json=_impl_payload("impl-86b"))
+        client.post(
+            "/tasks/impl-86b/result",
+            json=_completed_result("impl-86b", pr_number=42),
+        )
+    review = next(
+        t for t in TaskQueue(tmp_db).list_tasks() if t.task_type == "review"
+    )
+    instr = review.context["instructions"]
+    assert "gh pr diff 42" in instr
+    assert "FRESHNESS" in instr
+    assert "do NOT" in instr.lower() or "do not" in instr.lower()
+    # Reviewer must be reminded that earlier-round line numbers are stale.
+    assert "earlier" in instr.lower() or "prior" in instr.lower()
+
+
+def test_review_instructions_fallback_when_pr_number_missing(tmp_db):
+    push_calls: list = []
+    app = _make_app(tmp_db, push_calls)
+    with TestClient(app) as client:
+        client.post("/tasks", json=_impl_payload("impl-86c"))
+        # impl posts result with pr_number=None
+        client.post(
+            "/tasks/impl-86c/result",
+            json=_completed_result("impl-86c", pr_number=None),
+        )
+    review = next(
+        t for t in TaskQueue(tmp_db).list_tasks() if t.task_type == "review"
+    )
+    instr = review.context["instructions"]
+    # Even without pr_number, reviewer must be told to look up the PR via
+    # the branch and fetch the live diff — not review from a stale local
+    # checkout.
+    assert "gh pr list --head" in instr
+    assert "agent/agent_crew/claude" in instr
+    assert "FRESHNESS" in instr
+
+
+def test_review_pushed_to_reviewer_pane_on_impl_completion(tmp_db):
+    push_calls: list = []
+    app = _make_app(tmp_db, push_calls)
+    with TestClient(app) as client:
+        client.post("/tasks", json=_impl_payload("impl-86d"))
+        # First push: impl → claude pane (%C)
+        assert any(call[0] == "%C" for call in push_calls)
+        client.post(
+            "/tasks/impl-86d/result",
+            json=_completed_result("impl-86d", pr_number=99),
+        )
+    # Second push: review → codex pane (%X), and the message must contain
+    # the freshness directive that caused this whole bug.
+    review_pushes = [c for c in push_calls if c[0] == "%X"]
+    assert len(review_pushes) == 1
+    assert "gh pr diff 99" in review_pushes[0][1]


### PR DESCRIPTION
## Summary

Closes #86. When an impl task completes the auto-enqueued review task was missing two things: the PR number, and any instruction telling the reviewer to read the **latest** PR head rather than re-citing line numbers from the prior round. We hit this directly during #79 — round-2 fixes had already landed in commit \`79efaeb\`, but codex (handed a stale task description) re-flagged the exact three issues against commit \`4cc9820\`.

## Changes

- \`_auto_enqueue_review\` now accepts \`pr_number\`, threads it into \`context[\"pr_number\"]\`, and renders a \"FRESHNESS\" directive into \`context[\"instructions\"]\`:
  - When pr_number is known: tells the reviewer to run \`gh pr diff <n>\` (and/or \`gh pr view <n> --json commits\`) FIRST, and explicitly forbids reusing earlier line numbers.
  - When pr_number is None: falls back to \`gh pr list --head <branch>\` so the reviewer can still find the live PR before pinning findings.
- The HTTP \`submit_result\` handler passes \`result.pr_number\` into \`_auto_enqueue_review\`.

## Tests

\`tests/unit/test_review_freshness.py\` — 4 cases:
- pr_number from impl result lands on review context
- known PR → \`gh pr diff 42\` + FRESHNESS heading + don't-reuse-line-numbers warning in the rendered instructions
- missing PR → fallback \`gh pr list --head <branch>\` instruction
- the reviewer pane actually receives the directive in its push payload

Full suite: 264/267 passing — 3 \`test_cli\` failures pre-existing (#88).

🤖 Generated with [Claude Code](https://claude.com/claude-code)