### PR TITLE
fix(#88): patch write_instruction_files in recover tests

### DIFF
--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -266,6 +266,7 @@ def test_u_c20_recover_all_panes_alive_noop(tmp_path):
          patch("agent_crew.cli._pane_alive", return_value=True), \
          patch("agent_crew.cli.os.path.isdir", return_value=True), \
          patch("agent_crew.cli.subprocess.run", side_effect=_fake_run) as mock_run, \
+         patch("agent_crew.cli.setup_module.write_instruction_files"), \
          patch("agent_crew.cli.setup_module.start_agents_in_panes") as mock_start:
         result = runner.invoke(crew, ["recover", "rcproj", "--base", str(tmp_path)])
 
@@ -315,6 +316,7 @@ def test_u_c21_recover_recreates_only_dead_panes(tmp_path):
          patch("agent_crew.cli._pane_alive", side_effect=_fake_pane_alive), \
          patch("agent_crew.cli.os.path.isdir", return_value=True), \
          patch("agent_crew.cli.subprocess.run", side_effect=_fake_run) as mock_run, \
+         patch("agent_crew.cli.setup_module.write_instruction_files"), \
          patch("agent_crew.cli.setup_module.start_agents_in_panes") as mock_start:
         result = runner.invoke(crew, ["recover", "rcproj", "--base", str(tmp_path)])
 
@@ -371,7 +373,9 @@ def test_u_c22_recover_all_panes_dead_recreates_all(tmp_path):
     runner = CliRunner()
     with patch("agent_crew.cli._port_listening", return_value=True), \
          patch("agent_crew.cli._pane_alive", return_value=False), \
+         patch("agent_crew.cli.os.path.isdir", return_value=True), \
          patch("agent_crew.cli.subprocess.run", side_effect=_fake_run) as mock_run, \
+         patch("agent_crew.cli.setup_module.write_instruction_files"), \
          patch("agent_crew.cli.setup_module.start_agents_in_panes") as mock_start:
         result = runner.invoke(crew, ["recover", "rcproj", "--base", str(tmp_path)])
 


### PR DESCRIPTION
## Summary

Closes #88. \`test_u_c20_recover_all_panes_alive_noop\`, \`test_u_c21_recover_recreates_only_dead_panes\`, and \`test_u_c22_recover_all_panes_dead_recreates_all\` failed on a fresh checkout because \`recover()\` now reads the project's port file before re-emitting CLAUDE.md / AGENTS.md / GEMINI.md into each worktree. The synthetic test state never created that port file or those worktree directories, so \`instructions.write()\` crashed at \`open(port_file)\` and the runner came back with \`FileNotFoundError\`.

These tests are about pane validation logic, not instruction file regeneration. Patch \`setup_module.write_instruction_files\` in all three (and add the missing \`os.path.isdir=True\` mock to U-C22 to match the other two).

## Result

\`pytest tests/unit -q\` → **268/268 passing**. Clean baseline restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)