### PR TITLE
fix(#100): treat verdict=null + empty findings as approve

### DIFF
--- a/src/agent_crew/loop.py
+++ b/src/agent_crew/loop.py
@@ -102,6 +102,28 @@ def enqueue_test(queue, task_desc: str, branch: str, context: dict = {}, port: i
 _KNOWN_LAYERS = {"test_quality", "code_quality", "business_gap"}
 
 
+def _resolve_verdict(result: TaskResult) -> str:
+    """Map a TaskResult to one of {"approve", "request_changes"}.
+
+    Reviewer agents have been observed posting ``verdict=None`` with empty
+    ``findings`` when they have nothing to flag. The literal CLI rule
+    ``verdict == "approve"`` interprets that as a rejection and forces a
+    re-implementation round (issue #100 — codex, after a clean pass, sent
+    null/[] and the loop ran 4 unnecessary iterations).
+
+    Defensive read:
+    - explicit ``approve`` → ``approve``
+    - any value with non-empty findings → ``request_changes``
+    - missing/None verdict + empty findings → treat as ``approve``
+    """
+    if result.verdict == "approve":
+        return "approve"
+    findings = result.findings or []
+    if not result.verdict and not findings:
+        return "approve"
+    return "request_changes"
+
+
 def handle_review_result(
     result: TaskResult,
     iteration: int,
@@ -112,7 +134,8 @@ def handle_review_result(
     branch: str = "",
     port: int = 0,
 ) -> str:
-    if iteration >= max_iter and result.verdict != "approve":
+    verdict = _resolve_verdict(result)
+    if iteration >= max_iter and verdict != "approve":
         if queue is not None:
             gate = GateRequest(
                 id=f"gate-escalation-{uuid.uuid4().hex[:8]}",
@@ -121,7 +144,7 @@ def handle_review_result(
             )
             queue.create_gate(gate)
         return "escalate"
-    if result.verdict == "approve":
+    if verdict == "approve":
         if queue is not None and not no_tester and task_desc and branch:
             enqueue_test(queue, task_desc, branch, port=port)
         return "approved"

--- a/src/agent_crew/server.py
+++ b/src/agent_crew/server.py
@@ -20,6 +20,7 @@ from agent_crew.fallback import (
     load_fallback_chains,
     next_agent,
 )
+from agent_crew.loop import _resolve_verdict
 from agent_crew.notify import notify_telegram
 from agent_crew.protocol import GateRequest, TaskRequest, TaskResult
 from agent_crew.queue import TaskQueue, _ROLE_TO_TYPE, _TYPE_TO_ROLE
@@ -643,9 +644,14 @@ def create_app(
                 return
             review_task = review_tasks[0]
 
-            # Get the review result to confirm it was approved
+            # Get the review result to confirm it was approved. Use the
+            # defensive verdict resolver from loop.py so reviewers that
+            # post `verdict=null` with empty findings still trip the
+            # auto-test (#100).
             review_result = q().get_result(review_task_id)
-            if not review_result or review_result.verdict != "approve":
+            if not review_result:
+                return
+            if _resolve_verdict(review_result) != "approve":
                 return
 
             # Create test task with same description/branch, reference to review task
@@ -873,8 +879,10 @@ def create_app(
             if task_type == "implement" and result.status == "completed":
                 logger.info(f"POST /tasks/{task_id}/result: impl task completed, auto-enqueueing review")
                 _auto_enqueue_review(task_id, pr_number=result.pr_number)
-            # Auto-transition: review task approved → auto-enqueue test task
-            if task_type == "review" and result.verdict == "approve":
+            # Auto-transition: review approved → auto-enqueue test task. Use
+            # the defensive verdict resolver so a clean `verdict=null`+`[]`
+            # review counts as approved (#100).
+            if task_type == "review" and _resolve_verdict(result) == "approve":
                 logger.info(f"POST /tasks/{task_id}/result: review task approved, auto-enqueueing test")
                 _auto_enqueue_test(task_id)
             # Task done → that role is now idle → push the next pending task of the same role.

--- a/tests/unit/test_verdict_resolver.py
+++ b/tests/unit/test_verdict_resolver.py
@@ -1,0 +1,99 @@
+"""Defensive verdict parsing for `verdict=null` reviews (Issue #100).
+
+Reviewer agents have been observed sending ``verdict=null`` with empty
+``findings`` when they have nothing to flag. The literal CLI rule
+``verdict == "approve"`` interpreted that as a rejection and forced
+unnecessary re-implementation rounds.
+"""
+from agent_crew.loop import _resolve_verdict, handle_review_result
+from agent_crew.protocol import TaskResult
+
+
+def _result(verdict=None, findings=None, status="completed"):
+    return TaskResult(
+        task_id="t-1",
+        status=status,
+        summary="ok",
+        verdict=verdict,
+        findings=findings or [],
+        pr_number=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _resolve_verdict
+# ---------------------------------------------------------------------------
+
+
+class TestResolveVerdict:
+    def test_explicit_approve(self):
+        assert _resolve_verdict(_result(verdict="approve")) == "approve"
+
+    def test_explicit_request_changes(self):
+        assert _resolve_verdict(_result(verdict="request_changes")) == "request_changes"
+
+    def test_null_verdict_no_findings_treated_as_approve(self):
+        # The exact #100 scenario — codex sent verdict=None with [] findings.
+        assert _resolve_verdict(_result(verdict=None, findings=[])) == "approve"
+
+    def test_null_verdict_with_findings_is_request_changes(self):
+        result = _result(verdict=None, findings=["bug: off-by-one"])
+        assert _resolve_verdict(result) == "request_changes"
+
+    def test_empty_string_verdict_no_findings_is_approve(self):
+        # Some agents may send "" instead of null.
+        assert _resolve_verdict(_result(verdict="", findings=[])) == "approve"
+
+    def test_empty_string_verdict_with_findings_is_request_changes(self):
+        result = _result(verdict="", findings=[{"severity": "high", "msg": "x"}])
+        assert _resolve_verdict(result) == "request_changes"
+
+    def test_unknown_verdict_with_findings_is_request_changes(self):
+        # Defensive — anything that isn't 'approve' falls through.
+        result = _result(verdict="changes_requested", findings=["x"])
+        assert _resolve_verdict(result) == "request_changes"
+
+
+# ---------------------------------------------------------------------------
+# handle_review_result honors the resolver
+# ---------------------------------------------------------------------------
+
+
+class TestHandleReviewResult:
+    def test_null_verdict_clean_review_returns_approved(self):
+        outcome = handle_review_result(
+            _result(verdict=None, findings=[]),
+            iteration=2,
+            max_iter=5,
+            no_tester=True,
+        )
+        assert outcome == "approved"
+
+    def test_null_verdict_with_findings_returns_request_changes(self):
+        outcome = handle_review_result(
+            _result(verdict=None, findings=["unrelated nit"]),
+            iteration=2,
+            max_iter=5,
+            no_tester=True,
+        )
+        assert outcome == "request_changes"
+
+    def test_clean_null_at_max_iter_does_not_escalate(self):
+        """The #100 regression case: at iteration 5 of 5 with verdict=None
+        and empty findings, the loop must approve, not escalate."""
+        outcome = handle_review_result(
+            _result(verdict=None, findings=[]),
+            iteration=5,
+            max_iter=5,
+            no_tester=True,
+        )
+        assert outcome == "approved"
+
+    def test_request_changes_at_max_iter_escalates(self):
+        outcome = handle_review_result(
+            _result(verdict=None, findings=["real bug"]),
+            iteration=5,
+            max_iter=5,
+            no_tester=True,
+        )
+        assert outcome == "escalate"


### PR DESCRIPTION
## Summary

Closes #100. Reviewers (codex in the reported case) sometimes post \`verdict=null\` with empty \`findings\` after a clean pass. The literal check \`verdict == \"approve\"\` interpreted that as a rejection and forced 4 more re-implementation rounds until \`max_iter\` was hit and the loop escalated.

## Fix

New \`_resolve_verdict(result)\` in \`loop.py\` defensively maps:

| verdict | findings | resolved |
|---------|----------|----------|
| \`\"approve\"\` | any | \`approve\` |
| any non-approve | any | \`request_changes\` |
| \`null\` / \`\"\"\` | empty | \`approve\` |
| \`null\` / \`\"\"\` | non-empty | \`request_changes\` |

\`handle_review_result\` (the loop's CLI-side dispatcher) and both server-side verdict checks (\`_auto_enqueue_test\` gate at \`server.py:648\` and the \`submit_result\` auto-enqueue at \`server.py:877\`) all now route through the resolver, so any future verdict callsite stays consistent.

The reviewer instructions in \`instructions.py\` already document \"never post null\". The defensive parser is the real backstop — agents will ignore guidance from time to time, the loop should not break on that.

## Tests

11 new in \`tests/unit/test_verdict_resolver.py\`:
- Explicit \`approve\` / \`request_changes\` pass through unchanged
- \`null + []\` → \`approve\`
- \`null + [findings...]\` → \`request_changes\`
- \`\"\" + []\` and \`\"\" + [findings]\` likewise
- Unknown verdict strings with findings → \`request_changes\`
- \`handle_review_result\`: clean null at iteration 5 of 5 returns \`approved\` (not escalate); null with findings at max_iter still escalates correctly

Full suite: 292/292 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)