### PR TITLE
feat(#106): agent_override-aware dequeue + dynamic role prompt (phase 3)

### DIFF
--- a/src/agent_crew/mcp_server.py
+++ b/src/agent_crew/mcp_server.py
@@ -39,6 +39,17 @@ from agent_crew.queue import TaskQueue
 
 logger = logging.getLogger(__name__)
 
+# Default role per agent. The MCP `get_next_task(agent=...)` flow falls
+# back to this when no explicit ``role`` is passed, so each agent picks up
+# tasks of its primary type unless an override redirects work elsewhere.
+# Stays in lockstep with `setup._AGENT_TO_ROLE`; kept here so this module
+# stays free of `setup` import overhead.
+_DEFAULT_ROLE_FOR_AGENT: dict[str, str] = {
+    "claude": "implementer",
+    "codex": "reviewer",
+    "gemini": "tester",
+}
+
 
 def _task_to_dict(task: TaskRequest) -> dict[str, Any]:
     """Serialize a TaskRequest dataclass to a JSON-friendly dict."""
@@ -70,13 +81,26 @@ def build_mcp_server(
         agent: str = "",
         role: str = "",
     ) -> Optional[dict[str, Any]]:
-        """Pull the next task assigned to ``agent`` (or matching ``role``).
+        """Pull the next task for ``agent``.
 
-        Returns the task as a dict, or ``None`` when the queue has no work
-        ready for this agent. Tasks transition to ``in_progress`` atomically
-        — call ``submit_result`` when finished.
+        Resolution order matches `queue.dequeue` semantics:
+
+        - Tasks whose ``context.agent_override`` claims this agent come
+          first, regardless of task_type. Operator overrides
+          (``crew run --reviewer gemini``) and the rate-limit fallback
+          chain (#81) both rely on this path for dynamic role
+          reassignment.
+        - Otherwise the agent's *default* role is consulted — claude
+          picks implement, codex picks review, gemini picks test —
+          excluding tasks claimed by another agent's override. Pass an
+          explicit ``role=`` to override the default.
+
+        Returns the task as a JSON-friendly dict, or ``None`` when the
+        queue has no work ready. Tasks transition to ``in_progress``
+        atomically.
         """
-        task = queue.dequeue(agent=agent, role=role)
+        resolved_role = role or _DEFAULT_ROLE_FOR_AGENT.get(agent, "")
+        task = queue.dequeue(agent=agent, role=resolved_role)
         if task is None:
             return None
         return _task_to_dict(task)

--- a/src/agent_crew/prompts/task_loop.py
+++ b/src/agent_crew/prompts/task_loop.py
@@ -18,22 +18,19 @@ MCP tool surface in ``agent_crew/mcp_server.py``.
 """
 from __future__ import annotations
 
-# Mapping kept here (rather than imported from queue.py) so this module
-# stays free of runtime-data dependencies — tests can render prompts
-# without standing up SQLite.
-_ROLE_TO_TASK_TYPES: dict[str, tuple[str, ...]] = {
-    "implementer": ("implement",),
-    "reviewer": ("review",),
-    "tester": ("test",),
-    "panel": ("discuss",),
-}
-
-
 def build_task_loop_prompt(agent: str, role: str = "implementer") -> str:
-    """Return the full task-loop system prompt for ``agent`` in ``role``."""
+    """Return the full task-loop system prompt for ``agent``.
+
+    ``role`` is the agent's default role and informs the example call only.
+    The agent is *not* locked into that role — `get_next_task(agent=...)`
+    picks up tasks routed to this agent via ``context.agent_override``
+    even when their task_type doesn't match the default. That is what
+    enables dynamic role reassignment (#106 phase 3): operator overrides
+    via ``crew run --reviewer gemini`` and the rate-limit fallback chain
+    (#81) both work the same way — the task carries an override and the
+    agent picks it up regardless of its primary role.
+    """
     role_norm = role.lower() if role else "implementer"
-    types = _ROLE_TO_TASK_TYPES.get(role_norm, ("implement",))
-    types_str = " | ".join(types)
     return f"""You are {agent}, an agent in the agent_crew runtime.
 You have access to MCP tools from the "agent_crew" server.
 
@@ -43,21 +40,29 @@ Continuously execute this loop. Do NOT wait for tmux paste-buffer input —
 all task delivery goes through MCP tools below.
 
 ### 1. Pull the next task
-Call `get_next_task(agent="{agent}", role="{role_norm}")`.
-- Returns None → no work right now. Sleep 30 seconds, then call again.
-- Returns a task dict → proceed to step 2.
+Call `get_next_task(agent="{agent}")`.
+
+The server picks the right task for you based on:
+- Tasks routed to you via `context.agent_override` (operator override or
+  fallback chain) — regardless of task_type.
+- Otherwise tasks of your default role's task_type ({role_norm}).
+
+Returns:
+- None → no work right now. Sleep 30 seconds, then call again.
+- A task dict → proceed to step 2.
 
 ### 2. Read the task
 Required fields:
 - `task_id`: unique identifier (echo it back in submit_result)
-- `task_type`: one of {types_str}
+- `task_type`: `implement` | `review` | `test` | `discuss` — branch on this
+  to decide what to do (you may receive any type, not just your default)
 - `description`: natural-language prompt
 - `branch`: target git branch (may be empty for non-git tasks)
 - `priority`: integer, lower is higher priority
 - `context`: dict with task-specific fields (e.g. `pr_number`, `instructions`,
-  `prev_task_id`, `feedback`)
+  `prev_task_id`, `feedback`, `agent_override`)
 
-### 3. Execute the work
+### 3. Execute the work — branch on `task_type`
 
 **implement** — write tests first (TDD), implement until they pass, refactor,
 commit, open or update the PR. Set `pr_number` in `submit_result`.
@@ -111,11 +116,12 @@ def build_task_loop_prompt_compact(agent: str, role: str = "implementer") -> str
     version is enough to keep the loop alive until the next full session.
     """
     role_norm = role.lower() if role else "implementer"
-    return f"""You are {agent} ({role_norm}). agent_crew MCP tools available:
-get_next_task, submit_result, bump_activity, get_task, list_pending, cancel_task.
+    return f"""You are {agent} (default role: {role_norm}). agent_crew MCP tools \
+available: get_next_task, submit_result, bump_activity, get_task, list_pending, \
+cancel_task.
 
-Loop: get_next_task(agent="{agent}", role="{role_norm}") → execute → \
-bump_activity periodically → submit_result(...) → repeat. \
-Sleep 30s and retry on None. \
+Loop: get_next_task(agent="{agent}") → branch on task_type \
+(implement/review/test/discuss) → bump_activity periodically → \
+submit_result(...) → repeat. Sleep 30s on None. \
 On stuck: submit_result(status="needs_human", summary=<why>).
 """

--- a/src/agent_crew/queue.py
+++ b/src/agent_crew/queue.py
@@ -133,24 +133,71 @@ class TaskQueue:
         return task.task_id
 
     def dequeue(self, agent: str = "", role: str = "") -> Optional[TaskRequest]:
+        """Atomically dequeue the next pending task for ``agent`` / ``role``.
+
+        Resolution order (Issue #106 phase 3 — supports dynamic role
+        reassignment via ``context.agent_override``):
+
+        1. ``agent`` given: prefer tasks whose ``context.agent_override``
+           equals ``agent``, regardless of task_type. Operator overrides
+           (``crew run --reviewer gemini``) and the rate-limit fallback
+           chain both flow through this path.
+        2. ``role`` given (with or without ``agent``): tasks of the
+           matching task_type WHERE either no override is set or the
+           override claims this agent. The latter clause prevents an
+           agent from stealing a task explicitly routed to another
+           agent. Stage 2 only runs after stage 1 has no candidate.
+        3. Neither given: any pending task, ordered by priority.
+        """
         conn = self._connect()
         try:
             conn.execute("BEGIN IMMEDIATE")
-            if role:
+            row = None
+            if agent:
+                # Stage 1 — explicit override claim for this agent.
+                row = conn.execute(
+                    """
+                    SELECT * FROM tasks
+                    WHERE status = 'pending'
+                      AND json_extract(context, '$.agent_override') = ?
+                    ORDER BY priority ASC, created_at ASC
+                    LIMIT 1
+                    """,
+                    (agent,),
+                ).fetchone()
+
+            if row is None and role:
+                # Stage 2 — default role, skipping tasks claimed by others.
                 task_type_filter = _ROLE_TO_TYPE.get(role)
                 if task_type_filter is None:
                     conn.execute("ROLLBACK")
                     raise ValueError(f"Unknown role: {role!r}. Must be one of {list(_ROLE_TO_TYPE)}")
-                row = conn.execute(
-                    """
-                    SELECT * FROM tasks
-                    WHERE status = 'pending' AND task_type = ?
-                    ORDER BY priority ASC, created_at ASC
-                    LIMIT 1
-                    """,
-                    (task_type_filter,),
-                ).fetchone()
-            else:
+                if agent:
+                    row = conn.execute(
+                        """
+                        SELECT * FROM tasks
+                        WHERE status = 'pending' AND task_type = ?
+                          AND (
+                            json_extract(context, '$.agent_override') IS NULL
+                            OR json_extract(context, '$.agent_override') = ?
+                          )
+                        ORDER BY priority ASC, created_at ASC
+                        LIMIT 1
+                        """,
+                        (task_type_filter, agent),
+                    ).fetchone()
+                else:
+                    row = conn.execute(
+                        """
+                        SELECT * FROM tasks
+                        WHERE status = 'pending' AND task_type = ?
+                        ORDER BY priority ASC, created_at ASC
+                        LIMIT 1
+                        """,
+                        (task_type_filter,),
+                    ).fetchone()
+
+            if row is None and not agent and not role:
                 row = conn.execute(
                     """
                     SELECT * FROM tasks

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -90,6 +90,74 @@ class TestGetNextTask:
         assert result is not None
         assert result["task_id"] == "d-claude"
 
+    # ----- Phase 3 (#106): dynamic role reassignment via agent_override -----
+
+    def test_default_agent_role_resolved_when_role_omitted(self, tmp_db):
+        """Calling get_next_task with only an agent name must resolve the
+        agent's default role (claude→implementer)."""
+        TaskQueue(tmp_db).enqueue(_make_task("t-impl", task_type="implement"))
+        mcp = build_mcp_server(tmp_db)
+        result = _call_tool(mcp, "get_next_task", agent="claude")
+        assert result is not None
+        assert result["task_id"] == "t-impl"
+
+    def test_agent_override_pulls_off_role_task(self, tmp_db):
+        """Operator override (`crew run --reviewer gemini`) sets
+        agent_override on a review task. gemini (default tester) must
+        pick it up despite task_type=review."""
+        q = TaskQueue(tmp_db)
+        task = _make_task("t-rev-by-gemini", task_type="review")
+        task.context = {"agent_override": "gemini"}
+        q.enqueue(task)
+        mcp = build_mcp_server(tmp_db)
+        result = _call_tool(mcp, "get_next_task", agent="gemini")
+        assert result is not None
+        assert result["task_id"] == "t-rev-by-gemini"
+
+    def test_override_for_other_agent_blocks_pickup(self, tmp_db):
+        """A review task with agent_override="claude" must NOT be picked
+        up by codex even though codex is the default reviewer."""
+        q = TaskQueue(tmp_db)
+        task = _make_task("t-rev-fallback", task_type="review")
+        task.context = {"agent_override": "claude"}
+        q.enqueue(task)
+        mcp = build_mcp_server(tmp_db)
+        # codex sees no work — the review is claimed by claude.
+        assert _call_tool(mcp, "get_next_task", agent="codex") is None
+        # claude (default implementer) picks it up because the override claims it.
+        result = _call_tool(mcp, "get_next_task", agent="claude")
+        assert result is not None
+        assert result["task_id"] == "t-rev-fallback"
+
+    def test_override_takes_precedence_over_default_role(self, tmp_db):
+        """Two pending tasks: a default-role implement for claude, and
+        a review claimed by claude via override. The override task
+        wins because phase 1 of dequeue prefers explicit claims."""
+        q = TaskQueue(tmp_db)
+        # Default-role task for claude (no override).
+        q.enqueue(_make_task("t-impl-default", task_type="implement"))
+        # Override-claimed task.
+        review_task = _make_task("t-rev-override", task_type="review")
+        review_task.context = {"agent_override": "claude"}
+        q.enqueue(review_task)
+        mcp = build_mcp_server(tmp_db)
+        result = _call_tool(mcp, "get_next_task", agent="claude")
+        assert result is not None
+        assert result["task_id"] == "t-rev-override"
+
+    def test_explicit_role_overrides_default(self, tmp_db):
+        """Operator can still pass `role` explicitly when they need
+        a non-default routing."""
+        q = TaskQueue(tmp_db)
+        q.enqueue(_make_task("t-rev", task_type="review"))
+        mcp = build_mcp_server(tmp_db)
+        # claude asking for reviewer pulls the review even though its
+        # default role is implementer.
+        result = _call_tool(mcp, "get_next_task", agent="claude",
+                            role="reviewer")
+        assert result is not None
+        assert result["task_id"] == "t-rev"
+
 
 # ---------------------------------------------------------------------------
 # submit_result

--- a/tests/unit/test_task_loop_prompt.py
+++ b/tests/unit/test_task_loop_prompt.py
@@ -11,13 +11,18 @@ class TestFullPrompt:
         assert "claude" in p
         assert "[agent: claude]" in p
 
-    def test_role_drives_task_type_listing(self):
-        impl = build_task_loop_prompt("claude", role="implementer")
-        assert "one of implement" in impl
-        rev = build_task_loop_prompt("codex", role="reviewer")
-        assert "one of review" in rev
-        test = build_task_loop_prompt("gemini", role="tester")
-        assert "one of test" in test
+    def test_lists_all_task_types_for_dynamic_reassignment(self):
+        """Phase 3 (#106) — agents are no longer locked into a single
+        task_type. Every prompt must enumerate all four so the agent
+        knows how to dispatch when an override sends a non-default
+        type their way."""
+        for agent, role in [("claude", "implementer"), ("codex", "reviewer"),
+                            ("gemini", "tester")]:
+            p = build_task_loop_prompt(agent, role=role)
+            for task_type in ("implement", "review", "test", "discuss"):
+                assert task_type in p
+            # Default role still surfaces in the call example.
+            assert role in p
 
     def test_unknown_role_falls_back_to_implementer(self):
         p = build_task_loop_prompt("claude", role="weird")


### PR DESCRIPTION
## Summary

Phase 2 (#108) shipped MCP delivery but hardcoded each agent into a single \`task_type\`. That breaks two important reassignment paths:

| Scenario | Mechanism | What phase 2 missed |
|----------|-----------|---------------------|
| Operator override | \`crew run --reviewer gemini\` → \`context.agent_override = \"gemini\"\` on a review task | gemini's MCP loop only asks for \`role=\"tester\"\` so the review is invisible to it |
| Rate-limit fallback (#81) | codex limit → fallback enqueues a review with \`agent_override = \"claude\"\` | claude only pulls implement tasks, the rerouted review sits there |

Phase 3 fixes both: the queue dequeue and the agent-side prompt now both speak the agent_override contract.

## Changes

\`queue.dequeue(agent, role)\` — atomic two-stage selection:

```
1. agent given     → tasks where context.agent_override = agent
                     (any task_type, priority ordered)
2. role given      → tasks of matching task_type WHERE either no override
                     is set or the override claims this agent
3. neither         → any pending task
```

Both stages run inside a single \`BEGIN IMMEDIATE\` so concurrent agents never race the same task. SQL uses \`json_extract(context, '$.agent_override')\` which is already in use elsewhere in queue.py.

\`mcp_server.get_next_task(agent)\` resolves the agent's default role automatically (claude→implementer, codex→reviewer, gemini→tester) and passes both (agent, default_role) to \`queue.dequeue\`. Operators can still pass an explicit \`role=\` to override.

\`prompts/task_loop.py\`:
- Calls \`get_next_task(agent=\"...\")\` with no role — server picks
- Enumerates all four task_types (\`implement | review | test | discuss\`)
- Instructs agents to dispatch on the returned \`task_type\`, not on their own default role
- Same updates in the compact-restoration variant

## Tests

\`tests/unit/test_mcp_server.py\` (5 new phase-3 cases):
- default role auto-resolved when only \`agent\` passed
- operator override: review with \`agent_override=\"gemini\"\` is picked up by gemini despite default tester role
- other-agent override blocks default role pickup (codex won't steal a review claimed by claude)
- override beats default role when both candidates exist
- explicit \`role=\` overrides the agent default

\`tests/unit/test_task_loop_prompt.py\` — updated assertion to verify all four task_types are listed (replacing the role-locked check).

Full suite: 344/344 passing.

## Follow-up

Phase 4 (separate PR): start removing the push retry / watchdog reminder paths after we observe agents running cleanly on MCP in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)