### PR TITLE
fix(#110): per-agent instruction file paths + marker-bracketed merge

### DIFF
--- a/src/agent_crew/instructions.py
+++ b/src/agent_crew/instructions.py
@@ -2,16 +2,37 @@ import os
 
 from agent_crew.prompts.task_loop import build_task_loop_prompt
 
-# The agent_crew instructions are written to .claude/CLAUDE.md inside each
-# worktree so they do not conflict with the project's own root CLAUDE.md (which
-# is tracked in git and would be reverted by any git operation).  Claude Code
-# merges all CLAUDE.md files it finds (global + project root + .claude/), so
-# this file takes effect alongside — and takes priority over — the root one.
+# Per-role instruction file paths inside each worktree (Issue #110 fix).
+#
+# The naive ".claude/<NAME>.md" layout used to keep our prompts isolated
+# from the project's own git-tracked instructions, but it only worked for
+# Claude Code — that CLI is the one that merges its `.claude/CLAUDE.md`
+# with the project-root CLAUDE.md. Codex reads only `AGENTS.md` at the
+# project root; Gemini reads only `GEMINI.md` at the project root.
+# Putting our reviewer/tester prompts under `.claude/` meant the agents
+# never actually saw them, which led to gemini taking task descriptions
+# as implementer instructions and force-pushing over the implementer's
+# work (alpha_engine PRs #801–#805).
+#
+# Layout:
+#   implementer → ".claude/CLAUDE.md"   Claude Code merges with root.
+#   reviewer    → "AGENTS.md"           Codex reads this at the root.
+#   tester      → "GEMINI.md"           Gemini reads this at the root.
+#
+# AGENTS.md / GEMINI.md may already exist in the project (developer-facing
+# guides). To avoid clobbering them, `write()` uses a marker-bracketed
+# section that gets idempotently replaced on each rewrite — see
+# `_AGENT_CREW_BLOCK_*` below.
 ROLE_FILES: dict = {
     "implementer": ".claude/CLAUDE.md",
-    "reviewer": ".claude/AGENTS.md",
-    "tester": ".claude/GEMINI.md",
+    "reviewer": "AGENTS.md",
+    "tester": "GEMINI.md",
 }
+
+# Marker-bracketed block — the only region `write()` touches in
+# AGENTS.md / GEMINI.md so a project's own content is preserved.
+_AGENT_CREW_BLOCK_BEGIN = "<!-- agent_crew:begin -->"
+_AGENT_CREW_BLOCK_END = "<!-- agent_crew:end -->"
 
 # Default agent name per role — used when a caller passes role but not the
 # agent identifier. The agent name is what appears inside the task-loop
@@ -336,6 +357,31 @@ def generate(role: str, project: str, port: int, agent: str = "") -> str:
     return content
 
 
+def _merge_agent_crew_block(existing: str, new_block: str) -> str:
+    """Idempotently embed the agent_crew block inside an existing file.
+
+    AGENTS.md / GEMINI.md may carry developer-facing content that must be
+    preserved across regenerations (Issue #110). The marker-bracketed
+    block below is the only region we own; everything else is left
+    untouched.
+
+    Behaviour:
+    - First write: prepend ``BEGIN ... END`` block, blank line, then the
+      pre-existing content.
+    - Re-write: replace just the existing ``BEGIN ... END`` block in place,
+      preserving any content above or below it.
+    """
+    bracketed = f"{_AGENT_CREW_BLOCK_BEGIN}\n{new_block}\n{_AGENT_CREW_BLOCK_END}"
+    begin = existing.find(_AGENT_CREW_BLOCK_BEGIN)
+    end = existing.find(_AGENT_CREW_BLOCK_END)
+    if begin == -1 or end == -1 or end < begin:
+        if not existing:
+            return bracketed + "\n"
+        return bracketed + "\n\n" + existing
+    end_marker_close = end + len(_AGENT_CREW_BLOCK_END)
+    return existing[:begin] + bracketed + existing[end_marker_close:]
+
+
 def write(
     role: str,
     worktree_path: str,
@@ -348,9 +394,26 @@ def write(
     with open(port_file) as f:
         port = int(f.read().strip())
     filename = ROLE_FILES[role]
-    content = generate(role, project, port, agent=agent)
+    new_block = generate(role, project, port, agent=agent)
     path = os.path.join(worktree_path, filename)
-    os.makedirs(os.path.dirname(path), exist_ok=True)
+    parent = os.path.dirname(path)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+
+    if filename.startswith(".claude/"):
+        # `.claude/CLAUDE.md` is fully owned by agent_crew — overwrite
+        # entirely. No project-side content to preserve.
+        content = new_block
+    else:
+        existing = ""
+        if os.path.exists(path):
+            try:
+                with open(path) as f:
+                    existing = f.read()
+            except OSError:
+                existing = ""
+        content = _merge_agent_crew_block(existing, new_block)
+
     with open(path, "w") as f:
         f.write(content)
     return os.path.abspath(path)

--- a/tests/unit/test_instruction_paths.py
+++ b/tests/unit/test_instruction_paths.py
@@ -1,0 +1,169 @@
+"""Per-agent file paths for instruction docs (Issue #110).
+
+The previous layout wrote every role's prompt under `.claude/` so the
+files lived next to the project's git-tracked CLAUDE.md without
+clobbering it. That works for Claude Code (it merges `.claude/CLAUDE.md`
+with the root CLAUDE.md) but **codex reads only the root `AGENTS.md`**
+and **gemini reads only the root `GEMINI.md`** — so reviewer/tester
+prompts under `.claude/` were invisible to the agents that needed them.
+The tester took task descriptions as implementer instructions and
+force-pushed over the implementer's PR head (alpha_engine PRs #801–#805).
+
+After this PR:
+
+- implementer → `.claude/CLAUDE.md`  (Claude Code merges, full overwrite)
+- reviewer    → `AGENTS.md`           (project root, marker-bracketed)
+- tester      → `GEMINI.md`           (project root, marker-bracketed)
+
+Marker-bracketed writes preserve any developer-facing content the
+project already had in those files.
+"""
+import os
+
+from agent_crew import instructions
+
+
+def _write_port(tmp_path):
+    p = tmp_path / "port"
+    p.write_text("9123")
+    return str(p)
+
+
+# ---------------------------------------------------------------------------
+# ROLE_FILES: paths now match what each agent CLI actually reads
+# ---------------------------------------------------------------------------
+
+
+class TestRoleFiles:
+    def test_implementer_stays_under_dot_claude(self):
+        assert instructions.ROLE_FILES["implementer"] == ".claude/CLAUDE.md"
+
+    def test_reviewer_writes_to_root_agents_md(self):
+        # Codex reads ./AGENTS.md, not ./.claude/AGENTS.md.
+        assert instructions.ROLE_FILES["reviewer"] == "AGENTS.md"
+
+    def test_tester_writes_to_root_gemini_md(self):
+        # Gemini reads ./GEMINI.md, not ./.claude/GEMINI.md.
+        assert instructions.ROLE_FILES["tester"] == "GEMINI.md"
+
+
+# ---------------------------------------------------------------------------
+# write(): claude path stays a full overwrite, the other two get
+# marker-bracketed merges so project content is preserved.
+# ---------------------------------------------------------------------------
+
+
+class TestWriteImplementer:
+    def test_overwrites_dot_claude_claude_md(self, tmp_path):
+        wt = tmp_path / "wt"
+        wt.mkdir()
+        # Pre-existing .claude/CLAUDE.md should be replaced wholesale —
+        # we own this file.
+        old = wt / ".claude" / "CLAUDE.md"
+        old.parent.mkdir()
+        old.write_text("OLD CONTENT")
+        path = instructions.write(
+            "implementer",
+            str(wt),
+            project="proj",
+            port_file=_write_port(tmp_path),
+        )
+        body = open(path).read()
+        assert "OLD CONTENT" not in body
+        # task-loop prompt + agent_crew block are present
+        assert "You are claude" in body
+
+
+class TestWriteReviewer:
+    def test_first_write_creates_root_agents_md_with_block(self, tmp_path):
+        wt = tmp_path / "wt"
+        wt.mkdir()
+        path = instructions.write(
+            "reviewer",
+            str(wt),
+            project="proj",
+            port_file=_write_port(tmp_path),
+        )
+        assert path == os.path.abspath(str(wt / "AGENTS.md"))
+        body = open(path).read()
+        assert "<!-- agent_crew:begin -->" in body
+        assert "<!-- agent_crew:end -->" in body
+        assert "You are codex" in body
+
+    def test_preserves_existing_developer_doc(self, tmp_path):
+        wt = tmp_path / "wt"
+        wt.mkdir()
+        existing = "# Project Codex Guide\n\nUse 4-space indents.\n"
+        (wt / "AGENTS.md").write_text(existing)
+
+        path = instructions.write(
+            "reviewer",
+            str(wt),
+            project="proj",
+            port_file=_write_port(tmp_path),
+        )
+        body = open(path).read()
+        # Block prepended; original content preserved verbatim below.
+        assert body.startswith("<!-- agent_crew:begin -->")
+        assert "# Project Codex Guide" in body
+        assert "Use 4-space indents." in body
+
+    def test_idempotent_rewrite_replaces_only_marked_block(self, tmp_path):
+        wt = tmp_path / "wt"
+        wt.mkdir()
+        existing = (
+            "<!-- agent_crew:begin -->\nOLD AGENT CREW BLOCK\n<!-- agent_crew:end -->\n\n"
+            "# Project Codex Guide\nUse 4-space indents.\n"
+        )
+        (wt / "AGENTS.md").write_text(existing)
+
+        path = instructions.write(
+            "reviewer",
+            str(wt),
+            project="proj",
+            port_file=_write_port(tmp_path),
+        )
+        body = open(path).read()
+        assert "OLD AGENT CREW BLOCK" not in body  # replaced
+        assert "You are codex" in body              # new content present
+        assert "Use 4-space indents." in body       # project content preserved
+        # Markers appear exactly once each.
+        assert body.count("<!-- agent_crew:begin -->") == 1
+        assert body.count("<!-- agent_crew:end -->") == 1
+
+
+class TestWriteTester:
+    def test_first_write_creates_root_gemini_md_with_block(self, tmp_path):
+        wt = tmp_path / "wt"
+        wt.mkdir()
+        path = instructions.write(
+            "tester",
+            str(wt),
+            project="proj",
+            port_file=_write_port(tmp_path),
+        )
+        assert path == os.path.abspath(str(wt / "GEMINI.md"))
+        body = open(path).read()
+        assert "<!-- agent_crew:begin -->" in body
+        assert "You are gemini" in body
+        # Tester role section must communicate the verify-only constraint
+        # somewhere — covered indirectly by the body containing
+        # task_type=test branch instructions.
+        assert "test" in body
+
+    def test_preserves_existing_developer_doc(self, tmp_path):
+        wt = tmp_path / "wt"
+        wt.mkdir()
+        existing = "# Gemini Project Guide\n\nProject-specific tester notes.\n"
+        (wt / "GEMINI.md").write_text(existing)
+
+        path = instructions.write(
+            "tester",
+            str(wt),
+            project="proj",
+            port_file=_write_port(tmp_path),
+        )
+        body = open(path).read()
+        assert body.startswith("<!-- agent_crew:begin -->")
+        assert "# Gemini Project Guide" in body
+        assert "Project-specific tester notes." in body

--- a/tests/unit/test_instructions.py
+++ b/tests/unit/test_instructions.py
@@ -63,13 +63,24 @@ def test_u_i05_failure_path_documented():
     assert "needs direction" in content.lower() or "needs_human" in content
 
 
-def test_u_i06_role_files_use_dotclaude_subdir():
-    """Instructions must be written to .claude/ so they don't conflict with the
-    project's root CLAUDE.md (which is tracked in git and reverts on checkout)."""
-    for role, path in ROLE_FILES.items():
-        assert path.startswith(".claude/"), (
-            f"Role {role!r} uses {path!r} — must use .claude/ prefix to avoid git conflicts"
-        )
+def test_u_i06_role_files_match_each_agent_cli_lookup_path():
+    """Each role's instruction file must live where that agent's CLI
+    actually reads from (Issue #110):
+
+    - implementer (claude) → `.claude/CLAUDE.md` (Claude Code merges
+      with the project root CLAUDE.md without conflict)
+    - reviewer (codex)     → `AGENTS.md` (Codex reads only the
+      project-root copy)
+    - tester (gemini)      → `GEMINI.md` (Gemini reads only the
+      project-root copy)
+
+    The previous all-`.claude/` layout meant codex/gemini never saw
+    the agent_crew prompts and led to the tester force-pushing over
+    the implementer's PR head.
+    """
+    assert ROLE_FILES["implementer"] == ".claude/CLAUDE.md"
+    assert ROLE_FILES["reviewer"] == "AGENTS.md"
+    assert ROLE_FILES["tester"] == "GEMINI.md"
 
 
 def test_u_i07_common_instructs_ignore_alfred_global():


### PR DESCRIPTION
## Summary

Closes #110. The \`.claude/<NAME>.md\` layout depended on a Claude-Code-only behavior — merging \`.claude/CLAUDE.md\` with the project-root \`CLAUDE.md\`. Codex reads only the root \`AGENTS.md\`; Gemini reads only the root \`GEMINI.md\`. So our reviewer and tester prompts under \`.claude/\` were invisible to the agents that needed them.

Without those prompts, gemini took test-task descriptions as implementer instructions and force-pushed over the implementer's PR head (alpha_engine PRs #801–#805).

## Layout change

| Role | Old path | New path | Reason |
|------|----------|----------|--------|
| implementer | \`.claude/CLAUDE.md\` | \`.claude/CLAUDE.md\` | unchanged — Claude Code merges with root |
| reviewer | \`.claude/AGENTS.md\` | \`AGENTS.md\` | Codex reads only the root copy |
| tester | \`.claude/GEMINI.md\` | \`GEMINI.md\` | Gemini reads only the root copy |

## Marker-bracketed merge

Projects often already have a developer-facing \`AGENTS.md\` / \`GEMINI.md\`. \`write()\` now wraps the agent_crew prompt in:

\`\`\`
<!-- agent_crew:begin -->
... agent_crew prompt ...
<!-- agent_crew:end -->

(any pre-existing project content preserved below)
\`\`\`

Re-runs replace just the bracketed region. \`.claude/CLAUDE.md\` keeps its full-overwrite behavior — nothing else owns it.

## Tests

\`tests/unit/test_instruction_paths.py\` (9):
- \`ROLE_FILES\` per-agent layout
- implementer: full \`.claude/CLAUDE.md\` overwrite drops old contents
- reviewer/tester: first write creates marker block, preserves existing developer content; idempotent rewrite replaces only the bracketed region; marker count stays at 1

\`tests/unit/test_instructions.py:test_u_i06\` rewritten for the new layout (was the old "all under \`.claude/\`" assertion).

Full suite: 353/353 passing.

## Operational follow-up

After merge, every project needs \`crew recover\` to regenerate the role files at the new paths. Existing \`.claude/AGENTS.md\` and \`.claude/GEMINI.md\` files become orphaned — they don't hurt anything but can be cleaned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)