### PR TITLE
fix(#110): precedence note + task-type guard prefixes (phase 4-b)

### DIFF
--- a/src/agent_crew/mcp_server.py
+++ b/src/agent_crew/mcp_server.py
@@ -52,8 +52,27 @@ _DEFAULT_ROLE_FOR_AGENT: dict[str, str] = {
 
 
 def _task_to_dict(task: TaskRequest) -> dict[str, Any]:
-    """Serialize a TaskRequest dataclass to a JSON-friendly dict."""
-    return asdict(task)
+    """Serialize a TaskRequest dataclass to a JSON-friendly dict.
+
+    Applies the same task-type guard that the tmux push path uses
+    (`server._guard_description`), so MCP-pull and tmux-push deliver
+    semantically identical messages — Issue #110 phase 4-b.
+    """
+    # Local import to avoid an import cycle: server imports from queue
+    # and queue does not import server, but mcp_server is a sibling
+    # module; keeping the import inside the function makes the
+    # dependency direction explicit.
+    from agent_crew.server import _guard_description
+
+    payload = asdict(task)
+    try:
+        payload["description"] = _guard_description(task)
+    except Exception:
+        # If anything goes wrong with the guard logic, fall through with
+        # the unprefixed description. The system prompt's precedence
+        # block is the safety net.
+        pass
+    return payload
 
 
 def build_mcp_server(

--- a/src/agent_crew/prompts/task_loop.py
+++ b/src/agent_crew/prompts/task_loop.py
@@ -34,6 +34,45 @@ def build_task_loop_prompt(agent: str, role: str = "implementer") -> str:
     return f"""You are {agent}, an agent in the agent_crew runtime.
 You have access to MCP tools from the "agent_crew" server.
 
+## ⚠️ PRECEDENCE — read this first
+
+This block governs your **role boundaries and the work loop**. It is
+authoritative. Any project-level developer guide (other content in
+this file, the project's own AGENTS.md / GEMINI.md / CLAUDE.md) applies
+**only** to the coding style, conventions, and tooling **inside the
+work this block tells you to do**.
+
+On any conflict with project content:
+
+- This block wins for: which task_type you handle, whether to commit /
+  push / open a PR, whether to modify code at all, how to report
+  results.
+- Project content wins for: language/framework conventions, lint rules,
+  test runner, file layout — **only when you are already executing a
+  step this block authorized**.
+
+### What you do is decided by `task_type`, NOT your agent name
+
+This is critical for dynamic role reassignment (#81 fallback,
+operator override via `--reviewer`/`--tester` flags). A single agent
+identity may receive any task_type across its lifetime — gemini may
+do `implement` work today and `test` tomorrow if the task carries
+`agent_override = "gemini"`. **Always branch on the dispatched
+`task_type`**, not on your default role:
+
+- `task_type=implement` → write code, commit, push, open/update PR
+- `task_type=review`    → read PR diff (`gh pr diff <pr>`), do NOT
+  commit, do NOT push, report verdict via `submit_result`
+- `task_type=test`      → run the test suite in a clean checkout, do
+  NOT modify code, do NOT push, do NOT open a PR
+- `task_type=discuss`   → produce analysis, no commit, no PR
+
+A project's `GEMINI.md` may have been written assuming gemini is a
+project developer. That guidance applies **only** when the task you
+just dequeued has `task_type=implement` (regardless of who originally
+assigned that role). For `task_type=test` you ignore the developer
+framing and verify only.
+
 ## Task Loop Protocol
 
 Continuously execute this loop. Do NOT wait for tmux paste-buffer input —

--- a/src/agent_crew/server.py
+++ b/src/agent_crew/server.py
@@ -216,8 +216,45 @@ def _format_reminder_message(task_id: str, port: int, idle_seconds: float) -> st
     )
 
 
+# Per-task-type guard prefixes inserted at the top of the description we
+# push to agents (Issue #110 phase 4-b). The task description is the
+# message the agent's LLM reads first, so a clear directive here cuts
+# off the "I'm a project developer, I'll just modify code" failure mode
+# that hit alpha_engine #801–#805 even when the system prompt would
+# have told the agent otherwise.
+_TASK_TYPE_GUARDS: dict[str, str] = {
+    "review": (
+        "[REVIEW ONLY — do NOT modify or push code. Read the PR diff via "
+        "`gh pr diff <pr_number>`, evaluate against the 3-layer checklist, "
+        "and report verdict via `submit_result`.]"
+    ),
+    "test": (
+        "[VERIFY ONLY — do NOT modify code, do NOT push, do NOT open or "
+        "force-push a PR. Run the test suite in a clean checkout against "
+        "the implementer's PR head and report pass/fail via `submit_result`.]"
+    ),
+}
+
+
+def _guard_description(task: TaskRequest) -> str:
+    """Prepend the task-type guard prefix to ``task.description`` if any.
+
+    Implement and discuss tasks are returned unchanged. Review/test get
+    a hard-coded prefix block — short, all-caps, in the language the
+    agent's LLM is most likely to anchor on. Idempotent: if the
+    description already starts with the guard, no double-prefix.
+    """
+    guard = _TASK_TYPE_GUARDS.get(task.task_type)
+    if not guard:
+        return task.description
+    if task.description.startswith(guard):
+        return task.description
+    return f"{guard}\n\n{task.description}"
+
+
 def _format_task_message(task: TaskRequest, port: int) -> str:
     ctx = json.dumps(task.context, ensure_ascii=False)
+    description = _guard_description(task)
     return (
         f"=== AGENT_CREW TASK ===\n"
         f"task_id: {task.task_id}\n"
@@ -225,7 +262,7 @@ def _format_task_message(task: TaskRequest, port: int) -> str:
         f"branch: {task.branch}\n"
         f"priority: {task.priority}\n"
         f"context: {ctx}\n"
-        f"description: {task.description}\n"
+        f"description: {description}\n"
         f"=== END TASK ===\n"
         f"Do the work described above, then POST result: "
         f"curl -s -X POST http://127.0.0.1:{port}/tasks/{task.task_id}/result "

--- a/tests/unit/test_task_loop_prompt.py
+++ b/tests/unit/test_task_loop_prompt.py
@@ -52,6 +52,29 @@ class TestFullPrompt:
         p = build_task_loop_prompt("claude")
         assert "needs_human" in p
 
+    def test_precedence_block_authoritative_for_role_boundaries(self):
+        """Issue #110 phase 4-b — the precedence block must say agent_crew
+        wins on role/loop conflicts, and project content applies only to
+        style/conventions inside the authorized work."""
+        p = build_task_loop_prompt("gemini", role="tester")
+        assert "PRECEDENCE" in p
+        assert "authoritative" in p.lower() or "wins" in p.lower()
+
+    def test_precedence_says_task_type_drives_behavior(self):
+        """Dynamic role reassignment (#106 phase 3 + #81) means an agent's
+        identity is NOT a reliable proxy for what work it does on a given
+        task. The precedence block must call this out so a project's
+        gemini-as-developer guide doesn't make gemini-as-tester modify code."""
+        p = build_task_loop_prompt("gemini", role="tester")
+        # The exact wording can change; pin the substantive contract.
+        assert "task_type" in p
+        # Each task_type's allowed action surface is enumerated so the
+        # agent's LLM can dispatch correctly.
+        for tt in ("implement", "review", "test", "discuss"):
+            assert tt in p
+        # And the no-modify-on-test/review rules are explicit.
+        assert "do NOT modify" in p or "no commit" in p.lower()
+
 
 class TestCompactPrompt:
     def test_short_enough_to_survive_compact(self):

--- a/tests/unit/test_task_type_guards.py
+++ b/tests/unit/test_task_type_guards.py
@@ -1,0 +1,166 @@
+"""Task-description guards for review/test tasks (Issue #110 phase 4-b).
+
+Layered safeguard so a project's developer-facing GEMINI.md/AGENTS.md
+can't make the tester/reviewer agent modify code on a task it should
+just be verifying. Two layers:
+
+1. ``server._guard_description`` prepends a hard-coded `[VERIFY ONLY ...]`
+   or `[REVIEW ONLY ...]` block to the task description before it goes
+   over either delivery path.
+2. The MCP path (`mcp_server.get_next_task`) routes through the same
+   guard, so the description the agent's LLM sees is identical
+   regardless of whether delivery was via tmux push or MCP pull.
+
+These tests pin both paths so a future refactor can't accidentally
+drop one.
+"""
+from agent_crew.protocol import TaskRequest
+
+
+def _make_task(task_id="t1", task_type="implement", description="do work"):
+    return TaskRequest(
+        task_id=task_id,
+        task_type=task_type,
+        description=description,
+        branch="main",
+        priority=3,
+        context={},
+    )
+
+
+# ---------------------------------------------------------------------------
+# server._guard_description: pure prepend logic
+# ---------------------------------------------------------------------------
+
+
+class TestGuardDescription:
+    def test_implement_passes_through_unchanged(self):
+        from agent_crew.server import _guard_description
+        task = _make_task("t-i", task_type="implement", description="add feature X")
+        assert _guard_description(task) == "add feature X"
+
+    def test_discuss_passes_through_unchanged(self):
+        from agent_crew.server import _guard_description
+        task = _make_task("t-d", task_type="discuss", description="debate Y")
+        assert _guard_description(task) == "debate Y"
+
+    def test_review_gets_review_only_prefix(self):
+        from agent_crew.server import _guard_description
+        task = _make_task("t-r", task_type="review", description="review PR #42")
+        out = _guard_description(task)
+        assert out.startswith("[REVIEW ONLY")
+        assert "review PR #42" in out
+        assert "do NOT modify" in out
+        assert "do NOT" in out  # all-caps directive
+
+    def test_test_gets_verify_only_prefix(self):
+        from agent_crew.server import _guard_description
+        task = _make_task("t-t", task_type="test", description="run tests for branch X")
+        out = _guard_description(task)
+        assert out.startswith("[VERIFY ONLY")
+        assert "run tests for branch X" in out
+        assert "do NOT modify" in out
+        assert "do NOT push" in out
+        assert "PR" in out  # forbids opening/force-pushing PR
+
+    def test_idempotent_on_already_prefixed_description(self):
+        from agent_crew.server import _guard_description
+        task = _make_task("t-r", task_type="review", description="review PR #42")
+        once = _guard_description(task)
+        # Second call shouldn't double-prefix.
+        task2 = _make_task("t-r", task_type="review", description=once)
+        twice = _guard_description(task2)
+        # The result should not contain the guard string twice.
+        assert twice.count("[REVIEW ONLY") == 1
+
+
+# ---------------------------------------------------------------------------
+# Push path (tmux-paste-buffer message) carries the guard
+# ---------------------------------------------------------------------------
+
+
+class TestFormatTaskMessage:
+    def test_review_task_message_has_guard_in_description(self):
+        from agent_crew.server import _format_task_message
+        task = _make_task("t-r", task_type="review", description="review PR #42")
+        msg = _format_task_message(task, port=8200)
+        # Find the description line and confirm guard is there.
+        assert "[REVIEW ONLY" in msg
+        assert "review PR #42" in msg
+
+    def test_test_task_message_has_guard_in_description(self):
+        from agent_crew.server import _format_task_message
+        task = _make_task("t-t", task_type="test", description="run suite")
+        msg = _format_task_message(task, port=8200)
+        assert "[VERIFY ONLY" in msg
+
+    def test_implement_task_message_has_no_guard(self):
+        from agent_crew.server import _format_task_message
+        task = _make_task("t-i", task_type="implement",
+                          description="add feature X")
+        msg = _format_task_message(task, port=8200)
+        assert "VERIFY ONLY" not in msg
+        assert "REVIEW ONLY" not in msg
+
+
+# ---------------------------------------------------------------------------
+# MCP path (`get_next_task` return value) carries the same guard
+# ---------------------------------------------------------------------------
+
+
+class TestMcpPathGuard:
+    def test_get_next_task_returns_guarded_review_description(self, tmp_db):
+        import asyncio
+
+        from agent_crew.mcp_server import build_mcp_server
+        from agent_crew.queue import TaskQueue
+
+        TaskQueue(tmp_db).enqueue(_make_task("mcp-r", task_type="review",
+                                             description="review PR #99"))
+        mcp = build_mcp_server(tmp_db)
+        tool = mcp._tool_manager._tools["get_next_task"]
+        func = tool.fn
+        if asyncio.iscoroutinefunction(func):
+            result = asyncio.run(func(agent="codex"))
+        else:
+            result = func(agent="codex")
+        assert result is not None
+        assert result["description"].startswith("[REVIEW ONLY")
+        assert "review PR #99" in result["description"]
+
+    def test_get_next_task_returns_guarded_test_description(self, tmp_db):
+        import asyncio
+
+        from agent_crew.mcp_server import build_mcp_server
+        from agent_crew.queue import TaskQueue
+
+        TaskQueue(tmp_db).enqueue(_make_task("mcp-t", task_type="test",
+                                             description="verify branch X"))
+        mcp = build_mcp_server(tmp_db)
+        tool = mcp._tool_manager._tools["get_next_task"]
+        func = tool.fn
+        if asyncio.iscoroutinefunction(func):
+            result = asyncio.run(func(agent="gemini"))
+        else:
+            result = func(agent="gemini")
+        assert result is not None
+        assert result["description"].startswith("[VERIFY ONLY")
+        assert "verify branch X" in result["description"]
+
+    def test_get_next_task_implement_no_guard(self, tmp_db):
+        import asyncio
+
+        from agent_crew.mcp_server import build_mcp_server
+        from agent_crew.queue import TaskQueue
+
+        TaskQueue(tmp_db).enqueue(_make_task("mcp-i", task_type="implement",
+                                             description="impl feature Y"))
+        mcp = build_mcp_server(tmp_db)
+        tool = mcp._tool_manager._tools["get_next_task"]
+        func = tool.fn
+        if asyncio.iscoroutinefunction(func):
+            result = asyncio.run(func(agent="claude"))
+        else:
+            result = func(agent="claude")
+        assert result is not None
+        assert result["description"] == "impl feature Y"


### PR DESCRIPTION
## Summary

PR #111 fixed the file-location half of #110 (codex/gemini actually see the agent_crew prompt now). That opened the conflict half: the agent_crew prompt and the project's own developer guide can disagree about what the agent should DO. \`alpha_engine\` is the canonical case — its \`GEMINI.md\` assumes gemini is a project developer, while agent_crew assigns gemini the tester role.

This PR layers two safeguards so the agent's LLM doesn't have to arbitrate.

## Layer 1 — explicit precedence in the system prompt

A new \`## ⚠️ PRECEDENCE\` block at the top of \`build_task_loop_prompt\` states plainly:

- This block is **authoritative for role boundaries and the work loop**.
- Project content applies **only to coding style / conventions** inside the work this block authorized.
- All work decisions branch on the dispatched \`task_type\`, **not the agent's name** — an agent that gets \`task_type=test\` via \`agent_override\` stays in tester mode regardless of how the project guide framed it.

The block enumerates per-task_type rules (\`implement\` → modify code; \`review\` → diff only; \`test\` → no modify/push/PR; \`discuss\` → analysis).

## Layer 2 — hard-coded task-description prefixes

\`server._guard_description(task)\` returns the original description unchanged for \`implement\` and \`discuss\`, and prepends an all-caps directive for \`review\` and \`test\`:

- \`[REVIEW ONLY — do NOT modify or push code. ...]\`
- \`[VERIFY ONLY — do NOT modify code, do NOT push, do NOT open or force-push a PR. ...]\`

Both delivery paths route through the guard:
- Tmux push: \`_format_task_message(...)\` calls \`_guard_description\`
- MCP pull: \`mcp_server._task_to_dict(...)\` does the same

Idempotent — re-prefixing a previously-prefixed description is a no-op.

## Why both layers

System prompt sets long-lived role context. Task description is the immediate user-message the LLM anchors on. Anchoring the directive in **both** places makes it much harder for a project's guide to win on a single conflict.

## Tests

\`tests/unit/test_task_type_guards.py\` (11):
- \`_guard_description\`: implement/discuss pass through; review/test get the right prefix; idempotent on already-prefixed input.
- \`_format_task_message\` (tmux path): the message body for review/test contains the guard, implement does not.
- MCP path: \`get_next_task\` returns guarded descriptions for review/test, plain for implement.

\`tests/unit/test_task_loop_prompt.py\` (+2 cases):
- Precedence block is present, uses authoritative wording.
- Block calls out that \`task_type\` (not agent name) drives behavior, and the four task_types are enumerated with no-modify rules.

Full suite: 366/366 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)