### PR TITLE
feat(#110): per-agent MCP config — codex CODEX_HOME + gemini settings.json (phase 5)

### DIFF
--- a/src/agent_crew/setup.py
+++ b/src/agent_crew/setup.py
@@ -16,6 +16,13 @@ _DEFAULT_CMD = "claude --dangerously-skip-permissions --continue"
 
 
 def _get_agent_cmd(agent: str, worktree_path: str | None = None) -> str:
+    """Return the shell command that launches the agent CLI in its worktree.
+
+    For codex, prefixes ``CODEX_HOME=<wt>/.codex_local`` so the agent reads
+    a worktree-local config (Issue #110 phase 5 — per-agent MCP). codex
+    has no project-local config-file discovery, so the env var is the
+    only way to scope its MCP registration to a single project.
+    """
     cmd = _AGENT_CMDS.get(agent, _DEFAULT_CMD)
     if "--continue" in cmd:
         has_history = worktree_path is not None and os.path.isdir(
@@ -23,6 +30,9 @@ def _get_agent_cmd(agent: str, worktree_path: str | None = None) -> str:
         )
         if not has_history:
             cmd = cmd.replace(" --continue", "")
+    if agent == "codex" and worktree_path:
+        codex_home = os.path.join(worktree_path, ".codex_local")
+        cmd = f"CODEX_HOME={codex_home} {cmd}"
     return cmd
 
 
@@ -204,27 +214,25 @@ def write_instruction_files(worktrees: dict, project: str, port_file: str) -> No
         instructions.write(role, wt_path, project, port_file, agent=agent)
 
 
-def write_mcp_config(worktree_path: str, db_path: str) -> str:
-    """Write a Claude-Code-style ``.mcp.json`` that registers the agent_crew
-    MCP server (Issue #106). The agent picks this up at session start, gets
-    the seven task-queue tools, and runs the pull loop instead of waiting
-    for tmux paste-buffer pushes.
-
-    Existing files are overwritten so re-runs of `crew setup` / `crew recover`
-    always reflect the current DB path.
-    """
-    import json
+def _mcp_python_invocation() -> tuple[str, list[str], str]:
+    """Resolve (interpreter, args, PYTHONPATH) for launching the agent_crew
+    MCP server as a subprocess from any agent CLI."""
     import sys
 
-    # Pin python interpreter explicitly so the agent CLI doesn't pick up a
-    # different one from PATH. PYTHONPATH carries the agent_crew sys.path so
-    # the `python -m agent_crew.mcp_server` lookup succeeds.
+    interpreter = sys.executable
+    args = ["-m", "agent_crew.mcp_server"]
     pythonpath = os.pathsep.join(p for p in sys.path if p)
+    return interpreter, args, pythonpath
+
+
+def _write_mcp_config_claude(worktree_path: str, db_path: str) -> str:
+    """Claude Code reads ``.mcp.json`` at the worktree root."""
+    interpreter, args, pythonpath = _mcp_python_invocation()
     config = {
         "mcpServers": {
             "agent_crew": {
-                "command": sys.executable,
-                "args": ["-m", "agent_crew.mcp_server"],
+                "command": interpreter,
+                "args": args,
                 "env": {
                     "AGENT_CREW_DB": db_path,
                     "PYTHONPATH": pythonpath,
@@ -233,16 +241,100 @@ def write_mcp_config(worktree_path: str, db_path: str) -> str:
         }
     }
     path = os.path.join(worktree_path, ".mcp.json")
-    os.makedirs(os.path.dirname(path), exist_ok=True)
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
     with open(path, "w") as f:
         json.dump(config, f, indent=2)
     return os.path.abspath(path)
 
 
+def _write_mcp_config_codex(worktree_path: str, db_path: str) -> str:
+    """Codex looks at ``$CODEX_HOME/config.toml``. We point CODEX_HOME at
+    ``<worktree>/.codex_local`` from the agent's launch command (see
+    :func:`_get_agent_cmd`) and write the TOML here."""
+    interpreter, args, pythonpath = _mcp_python_invocation()
+    args_repr = "[" + ", ".join(f'"{a}"' for a in args) + "]"
+    toml_text = (
+        '[mcp_servers.agent_crew]\n'
+        f'command = "{interpreter}"\n'
+        f'args = {args_repr}\n'
+        '[mcp_servers.agent_crew.env]\n'
+        f'AGENT_CREW_DB = "{db_path}"\n'
+        f'PYTHONPATH = "{pythonpath}"\n'
+    )
+    codex_home = os.path.join(worktree_path, ".codex_local")
+    os.makedirs(codex_home, exist_ok=True)
+    path = os.path.join(codex_home, "config.toml")
+    with open(path, "w") as f:
+        f.write(toml_text)
+    return os.path.abspath(path)
+
+
+def _write_mcp_config_gemini(worktree_path: str, db_path: str) -> str:
+    """Gemini auto-discovers ``<worktree>/.gemini/settings.json`` when run
+    from inside the worktree (project scope). We merge our `mcpServers`
+    block into whatever else might already live there."""
+    interpreter, args, pythonpath = _mcp_python_invocation()
+    settings_dir = os.path.join(worktree_path, ".gemini")
+    os.makedirs(settings_dir, exist_ok=True)
+    path = os.path.join(settings_dir, "settings.json")
+    existing: dict = {}
+    if os.path.exists(path):
+        try:
+            with open(path) as f:
+                existing = json.load(f) or {}
+            if not isinstance(existing, dict):
+                existing = {}
+        except (OSError, json.JSONDecodeError):
+            existing = {}
+    servers = existing.get("mcpServers")
+    if not isinstance(servers, dict):
+        servers = {}
+    servers["agent_crew"] = {
+        "command": interpreter,
+        "args": args,
+        "env": {
+            "AGENT_CREW_DB": db_path,
+            "PYTHONPATH": pythonpath,
+        },
+    }
+    existing["mcpServers"] = servers
+    with open(path, "w") as f:
+        json.dump(existing, f, indent=2)
+    return os.path.abspath(path)
+
+
+def write_mcp_config(
+    worktree_path: str,
+    db_path: str,
+    agent: str = "claude",
+) -> str:
+    """Write the per-worktree MCP config for ``agent``.
+
+    Each agent CLI reads its MCP registration from a different place,
+    so the default Claude-Code ``.mcp.json`` we used in #106 phase 2 was
+    invisible to codex and gemini (Issue #110 phase 5):
+
+    - claude → ``<worktree>/.mcp.json``
+    - codex  → ``<worktree>/.codex_local/config.toml`` (with ``CODEX_HOME``
+      env on launch — see ``_get_agent_cmd``)
+    - gemini → ``<worktree>/.gemini/settings.json`` (auto-discovered when
+      gemini is launched from the worktree)
+
+    Falls back to the claude path for unknown agent names so legacy
+    callers and ad-hoc one-off agents keep working.
+    """
+    if agent == "codex":
+        return _write_mcp_config_codex(worktree_path, db_path)
+    if agent == "gemini":
+        return _write_mcp_config_gemini(worktree_path, db_path)
+    return _write_mcp_config_claude(worktree_path, db_path)
+
+
 def write_mcp_configs(worktrees: dict, db_path: str) -> None:
-    """Apply :func:`write_mcp_config` to every agent worktree."""
-    for wt_path in worktrees.values():
-        write_mcp_config(wt_path, db_path)
+    """Apply :func:`write_mcp_config` to every agent worktree using the
+    correct per-agent config layout."""
+    for agent, wt_path in worktrees.items():
+        write_mcp_config(wt_path, db_path, agent=agent)
 
 
 def write_sessions_json(path: str, agents: list[dict]) -> None:

--- a/tests/unit/test_mcp_config_per_agent.py
+++ b/tests/unit/test_mcp_config_per_agent.py
@@ -1,0 +1,188 @@
+"""Per-agent MCP config writing (Issue #110 phase 5).
+
+`write_mcp_config(worktree_path, db_path, agent=...)` now writes to the
+file the named agent's CLI actually reads at session start:
+
+  claude → `<wt>/.mcp.json`                       (Claude Code default)
+  codex  → `<wt>/.codex_local/config.toml`        (CODEX_HOME=...
+                                                   override on launch)
+  gemini → `<wt>/.gemini/settings.json`           (project-scope auto-
+                                                   discovered when run
+                                                   from the worktree)
+
+The earlier all-`.mcp.json` setup was invisible to codex/gemini, which
+is why those agents fell back to HTTP polling and never picked up MCP
+tools — see issue #110 comments.
+"""
+import json
+import os
+
+from agent_crew import setup as crew_setup
+
+
+# ---------------------------------------------------------------------------
+# claude (.mcp.json) — preserved from phase 2
+# ---------------------------------------------------------------------------
+
+
+class TestClaudeMcpConfig:
+    def test_writes_dot_mcp_json_at_worktree_root(self, tmp_path):
+        wt = tmp_path / "wt"
+        wt.mkdir()
+        path = crew_setup.write_mcp_config(str(wt), "/db.db", agent="claude")
+        assert path == os.path.abspath(str(wt / ".mcp.json"))
+        config = json.loads((wt / ".mcp.json").read_text())
+        assert "agent_crew" in config["mcpServers"]
+        assert config["mcpServers"]["agent_crew"]["env"]["AGENT_CREW_DB"] == "/db.db"
+
+    def test_default_agent_is_claude(self, tmp_path):
+        # write_mcp_config without `agent=` falls back to claude path,
+        # mirroring the legacy phase-2 contract.
+        wt = tmp_path / "wt"
+        wt.mkdir()
+        path = crew_setup.write_mcp_config(str(wt), "/db.db")
+        assert path.endswith(".mcp.json")
+
+
+# ---------------------------------------------------------------------------
+# codex (.codex_local/config.toml + CODEX_HOME)
+# ---------------------------------------------------------------------------
+
+
+class TestCodexMcpConfig:
+    def test_writes_codex_local_config_toml(self, tmp_path):
+        wt = tmp_path / "wt"
+        wt.mkdir()
+        path = crew_setup.write_mcp_config(str(wt), "/db.db", agent="codex")
+        assert path == os.path.abspath(str(wt / ".codex_local" / "config.toml"))
+        body = (wt / ".codex_local" / "config.toml").read_text()
+        # TOML format: section header + key=value lines.
+        assert "[mcp_servers.agent_crew]" in body
+        assert "agent_crew.mcp_server" in body
+        assert 'AGENT_CREW_DB = "/db.db"' in body
+        assert "PYTHONPATH = " in body
+
+    def test_get_agent_cmd_prefixes_codex_home(self, tmp_path):
+        wt = tmp_path / "wt"
+        wt.mkdir()
+        cmd = crew_setup._get_agent_cmd("codex", worktree_path=str(wt))
+        assert cmd.startswith("CODEX_HOME=")
+        assert ".codex_local" in cmd
+        assert "codex --dangerously-bypass-approvals-and-sandbox" in cmd
+
+    def test_get_agent_cmd_no_prefix_when_no_worktree(self):
+        # Operator-invoked codex without a worktree context → no prefix.
+        cmd = crew_setup._get_agent_cmd("codex", worktree_path=None)
+        assert "CODEX_HOME=" not in cmd
+
+    def test_overwrites_existing_config(self, tmp_path):
+        wt = tmp_path / "wt"
+        wt.mkdir()
+        crew_setup.write_mcp_config(str(wt), "/v1.db", agent="codex")
+        crew_setup.write_mcp_config(str(wt), "/v2.db", agent="codex")
+        body = (wt / ".codex_local" / "config.toml").read_text()
+        assert '"/v2.db"' in body
+        assert '"/v1.db"' not in body
+
+
+# ---------------------------------------------------------------------------
+# gemini (.gemini/settings.json) — JSON, project-scope auto-discovery
+# ---------------------------------------------------------------------------
+
+
+class TestGeminiMcpConfig:
+    def test_writes_dot_gemini_settings_json(self, tmp_path):
+        wt = tmp_path / "wt"
+        wt.mkdir()
+        path = crew_setup.write_mcp_config(str(wt), "/db.db", agent="gemini")
+        assert path == os.path.abspath(str(wt / ".gemini" / "settings.json"))
+        data = json.loads((wt / ".gemini" / "settings.json").read_text())
+        assert "agent_crew" in data["mcpServers"]
+        assert data["mcpServers"]["agent_crew"]["env"]["AGENT_CREW_DB"] == "/db.db"
+
+    def test_preserves_existing_settings_keys(self, tmp_path):
+        wt = tmp_path / "wt"
+        gemini_dir = wt / ".gemini"
+        gemini_dir.mkdir(parents=True)
+        # Project may already have other gemini config (theme, security, etc.)
+        existing = {
+            "security": {"auth": {"selectedType": "oauth-personal"}},
+            "ui": {"theme": "dark"},
+        }
+        (gemini_dir / "settings.json").write_text(json.dumps(existing))
+
+        crew_setup.write_mcp_config(str(wt), "/db.db", agent="gemini")
+        data = json.loads((gemini_dir / "settings.json").read_text())
+        assert data["security"]["auth"]["selectedType"] == "oauth-personal"
+        assert data["ui"]["theme"] == "dark"
+        assert "agent_crew" in data["mcpServers"]
+
+    def test_merges_into_existing_mcp_servers_block(self, tmp_path):
+        wt = tmp_path / "wt"
+        gemini_dir = wt / ".gemini"
+        gemini_dir.mkdir(parents=True)
+        existing = {
+            "mcpServers": {
+                "other_tool": {"command": "tool", "args": []},
+            }
+        }
+        (gemini_dir / "settings.json").write_text(json.dumps(existing))
+
+        crew_setup.write_mcp_config(str(wt), "/db.db", agent="gemini")
+        data = json.loads((gemini_dir / "settings.json").read_text())
+        # Both entries present.
+        assert "other_tool" in data["mcpServers"]
+        assert "agent_crew" in data["mcpServers"]
+
+    def test_overwrites_only_agent_crew_entry(self, tmp_path):
+        wt = tmp_path / "wt"
+        gemini_dir = wt / ".gemini"
+        gemini_dir.mkdir(parents=True)
+        existing = {
+            "mcpServers": {
+                "other_tool": {"command": "tool", "args": []},
+                "agent_crew": {"command": "stale", "args": []},
+            }
+        }
+        (gemini_dir / "settings.json").write_text(json.dumps(existing))
+
+        crew_setup.write_mcp_config(str(wt), "/v2.db", agent="gemini")
+        data = json.loads((gemini_dir / "settings.json").read_text())
+        assert data["mcpServers"]["other_tool"]["command"] == "tool"
+        assert data["mcpServers"]["agent_crew"]["command"] != "stale"
+        assert data["mcpServers"]["agent_crew"]["env"]["AGENT_CREW_DB"] == "/v2.db"
+
+    def test_handles_invalid_json_gracefully(self, tmp_path):
+        """A corrupt settings.json shouldn't crash; the agent_crew block
+        gets written and any non-recoverable fields are dropped."""
+        wt = tmp_path / "wt"
+        gemini_dir = wt / ".gemini"
+        gemini_dir.mkdir(parents=True)
+        (gemini_dir / "settings.json").write_text("{ this is not json")
+
+        crew_setup.write_mcp_config(str(wt), "/db.db", agent="gemini")
+        data = json.loads((gemini_dir / "settings.json").read_text())
+        assert "agent_crew" in data["mcpServers"]
+
+
+# ---------------------------------------------------------------------------
+# write_mcp_configs(worktrees, db) dispatches by agent name
+# ---------------------------------------------------------------------------
+
+
+class TestWriteMcpConfigsDispatch:
+    def test_each_agent_gets_its_own_layout(self, tmp_path):
+        wt_c = tmp_path / "claude"
+        wt_x = tmp_path / "codex"
+        wt_g = tmp_path / "gemini"
+        for p in (wt_c, wt_x, wt_g):
+            p.mkdir()
+        worktrees = {
+            "claude": str(wt_c),
+            "codex": str(wt_x),
+            "gemini": str(wt_g),
+        }
+        crew_setup.write_mcp_configs(worktrees, "/db.db")
+        assert (wt_c / ".mcp.json").exists()
+        assert (wt_x / ".codex_local" / "config.toml").exists()
+        assert (wt_g / ".gemini" / "settings.json").exists()

--- a/tests/unit/test_mcp_wiring.py
+++ b/tests/unit/test_mcp_wiring.py
@@ -98,14 +98,27 @@ class TestWriteMcpConfig:
 
 
 class TestWriteMcpConfigs:
-    def test_applies_to_each_worktree(self, tmp_path):
-        wt_a = tmp_path / "a"
-        wt_b = tmp_path / "b"
-        wt_a.mkdir()
-        wt_b.mkdir()
-        worktrees = {"claude": str(wt_a), "codex": str(wt_b)}
+    def test_applies_correct_layout_per_agent(self, tmp_path):
+        """Phase 5 (#110): each agent's config file lives where that
+        CLI actually reads it from. Detailed per-agent assertions live
+        in test_mcp_config_per_agent.py — this is the dispatch smoke
+        test."""
+        wt_c = tmp_path / "c"
+        wt_x = tmp_path / "x"
+        wt_g = tmp_path / "g"
+        for p in (wt_c, wt_x, wt_g):
+            p.mkdir()
+        worktrees = {
+            "claude": str(wt_c),
+            "codex": str(wt_x),
+            "gemini": str(wt_g),
+        }
         crew_setup.write_mcp_configs(worktrees, "/db/tasks.db")
-        for wt in (wt_a, wt_b):
-            assert (wt / ".mcp.json").exists()
-            config = json.loads((wt / ".mcp.json").read_text())
-            assert config["mcpServers"]["agent_crew"]["env"]["AGENT_CREW_DB"] == "/db/tasks.db"
+        # claude → .mcp.json
+        assert (wt_c / ".mcp.json").exists()
+        config = json.loads((wt_c / ".mcp.json").read_text())
+        assert config["mcpServers"]["agent_crew"]["env"]["AGENT_CREW_DB"] == "/db/tasks.db"
+        # codex → .codex_local/config.toml
+        assert (wt_x / ".codex_local" / "config.toml").exists()
+        # gemini → .gemini/settings.json
+        assert (wt_g / ".gemini" / "settings.json").exists()


### PR DESCRIPTION
## Summary

Phase 2 of #106 wrote \`.mcp.json\` to every worktree on the assumption all three agent CLIs would read it. Only Claude Code does. After phase 4-b landed and we verified on \`claude_autonomous_trader\`:

- ✅ claude (%690): MCP works, calls \`get_next_task\` via the agent_crew server, schedules \`/loop\` wakeups.
- ❌ codex (%691): "agent_crew MCP server is not exposed in this session" — falls back to direct HTTP polling.
- ❌ gemini (%692): same — never sees the MCP tools, hallucinates queue state.

This PR adds the codex and gemini config layouts.

## Layout

| Agent | Path | Notes |
|-------|------|-------|
| claude | \`<wt>/.mcp.json\` | unchanged from phase 2 |
| codex | \`<wt>/.codex_local/config.toml\` | TOML; codex reads via \`CODEX_HOME=...\` env |
| gemini | \`<wt>/.gemini/settings.json\` | JSON; gemini auto-discovers when run from cwd |

## Changes

- \`setup.write_mcp_config(worktree, db, agent=...)\` branches on agent name. Default still falls back to the claude path so legacy callers work unchanged.
- \`setup._get_agent_cmd(\"codex\", worktree)\` prefixes \`CODEX_HOME=<wt>/.codex_local\` so codex picks up the worktree-local TOML at launch. Claude and gemini auto-discover from cwd, so no launch-env change for them.
- The gemini writer is **merge-safe**: existing \`.gemini/settings.json\` content (theme, security, other MCP servers) is preserved; only the \`agent_crew\` entry under \`mcpServers\` is touched. Corrupt JSON is treated as empty and the agent_crew block is written cleanly.
- \`setup.write_mcp_configs(worktrees, db)\` now dispatches by agent name in one call.

## Tests

\`tests/unit/test_mcp_config_per_agent.py\` (12 new):
- claude: \`.mcp.json\` written; default agent fallback is claude
- codex: TOML at \`.codex_local/config.toml\`; \`_get_agent_cmd\` prefixes \`CODEX_HOME=\`; no prefix when called without a worktree; overwrite semantics
- gemini: project-local settings.json written; preserves existing non-mcpServers keys; merges into existing mcpServers block; overwrites only the \`agent_crew\` entry; recovers from corrupt JSON
- dispatch test: \`write_mcp_configs\` produces the right file at the right path for each agent in one call

\`tests/unit/test_mcp_wiring.py\` legacy "all-\`.mcp.json\`" assertion rewritten.

Full suite: **378/378 passing**.

## Operational notes

After merge, every project needs \`crew recover\` to materialize the new files in each worktree. Existing \`.mcp.json\` in codex/gemini worktrees becomes orphaned — they're harmless but can be cleaned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)