### PR TITLE
feat(#110): codex auth bootstrap + gemini --approval-mode yolo (phase 5b)

### DIFF
--- a/src/agent_crew/setup.py
+++ b/src/agent_crew/setup.py
@@ -10,7 +10,11 @@ from agent_crew import instructions, session
 _AGENT_CMDS = {
     "claude": "claude --dangerously-skip-permissions --continue",
     "codex": "codex --dangerously-bypass-approvals-and-sandbox",
-    "gemini": "gemini --yolo",
+    # ``--approval-mode yolo`` is the policy-engine flag that fully
+    # bypasses every tool prompt (including shell/git which the legacy
+    # ``--yolo`` short flag was observed to miss when an MCP server is
+    # registered alongside built-in tools — Issue #110 phase 5b).
+    "gemini": "gemini --approval-mode yolo",
 }
 _DEFAULT_CMD = "claude --dangerously-skip-permissions --continue"
 
@@ -247,6 +251,33 @@ def _write_mcp_config_claude(worktree_path: str, db_path: str) -> str:
     return os.path.abspath(path)
 
 
+def _bootstrap_codex_auth(codex_home: str) -> None:
+    """Copy ``~/.codex/auth.json`` into a worktree-local ``$CODEX_HOME``.
+
+    With ``CODEX_HOME=<wt>/.codex_local`` codex no longer falls back to
+    ``~/.codex`` for authentication — it would prompt for a fresh OAuth
+    flow on every worktree. Reuse the operator's existing auth by
+    copying the credentials file in once at setup. We do NOT symlink
+    because codex rewrites this file on token refresh and the symlink
+    could leak token expiry between unrelated sessions.
+
+    Idempotent: skipped silently when the global file is missing or
+    already mirrored. Permission mode 0600 is preserved.
+    """
+    src = os.path.expanduser("~/.codex/auth.json")
+    if not os.path.isfile(src):
+        return
+    dst = os.path.join(codex_home, "auth.json")
+    try:
+        with open(src, "rb") as fsrc, open(dst, "wb") as fdst:
+            fdst.write(fsrc.read())
+        os.chmod(dst, 0o600)
+    except OSError:
+        # Don't crash setup over a missing auth file — codex will just
+        # prompt the user to log in once when it next starts up.
+        return
+
+
 def _write_mcp_config_codex(worktree_path: str, db_path: str) -> str:
     """Codex looks at ``$CODEX_HOME/config.toml``. We point CODEX_HOME at
     ``<worktree>/.codex_local`` from the agent's launch command (see
@@ -266,6 +297,7 @@ def _write_mcp_config_codex(worktree_path: str, db_path: str) -> str:
     path = os.path.join(codex_home, "config.toml")
     with open(path, "w") as f:
         f.write(toml_text)
+    _bootstrap_codex_auth(codex_home)
     return os.path.abspath(path)
 
 

--- a/tests/unit/test_codex_auth_bootstrap.py
+++ b/tests/unit/test_codex_auth_bootstrap.py
@@ -1,0 +1,115 @@
+"""Codex auth bootstrap into worktree-local CODEX_HOME (Issue #110 phase 5b).
+
+`_get_agent_cmd("codex", worktree)` points codex at `<wt>/.codex_local`,
+which means codex no longer falls back to `~/.codex` and would prompt
+for a fresh OAuth flow on every worktree. To preserve the operator's
+existing login, `setup._write_mcp_config_codex` mirrors
+`~/.codex/auth.json` into the worktree's CODEX_HOME at config-write
+time. These tests pin that contract.
+"""
+import os
+import stat
+from unittest.mock import patch
+
+from agent_crew import setup as crew_setup
+
+
+class TestBootstrapCodexAuth:
+    def test_copies_global_auth_into_codex_home(self, tmp_path):
+        # Synthetic ~/.codex/auth.json at a fake HOME so the test never
+        # touches the real one.
+        fake_home = tmp_path / "fake_home"
+        global_dir = fake_home / ".codex"
+        global_dir.mkdir(parents=True)
+        global_auth = global_dir / "auth.json"
+        global_auth.write_text("{\"token\":\"abc123\"}")
+        os.chmod(global_auth, 0o600)
+
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+        codex_home = worktree / ".codex_local"
+        codex_home.mkdir()
+
+        with patch.dict(os.environ, {"HOME": str(fake_home)}):
+            crew_setup._bootstrap_codex_auth(str(codex_home))
+
+        copied = codex_home / "auth.json"
+        assert copied.exists()
+        assert copied.read_text() == "{\"token\":\"abc123\"}"
+        # Mode must be 0600 — credentials file.
+        mode = stat.S_IMODE(copied.stat().st_mode)
+        assert mode == 0o600
+
+    def test_silent_skip_when_global_missing(self, tmp_path):
+        fake_home = tmp_path / "fake_home"
+        fake_home.mkdir()  # no .codex/ dir
+
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+        codex_home = worktree / ".codex_local"
+        codex_home.mkdir()
+
+        with patch.dict(os.environ, {"HOME": str(fake_home)}):
+            # Must NOT raise.
+            crew_setup._bootstrap_codex_auth(str(codex_home))
+
+        assert not (codex_home / "auth.json").exists()
+
+    def test_idempotent_on_existing_local_auth(self, tmp_path):
+        fake_home = tmp_path / "fake_home"
+        global_dir = fake_home / ".codex"
+        global_dir.mkdir(parents=True)
+        global_auth = global_dir / "auth.json"
+        global_auth.write_text("{\"token\":\"new\"}")
+
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+        codex_home = worktree / ".codex_local"
+        codex_home.mkdir()
+        # Pre-existing local auth from a stale setup run.
+        local_auth = codex_home / "auth.json"
+        local_auth.write_text("{\"token\":\"stale\"}")
+
+        with patch.dict(os.environ, {"HOME": str(fake_home)}):
+            crew_setup._bootstrap_codex_auth(str(codex_home))
+
+        # Bootstrap should refresh the local copy with the global one
+        # (codex rewrites this file on token refresh, so always-up-to-date
+        # is the right contract).
+        assert local_auth.read_text() == "{\"token\":\"new\"}"
+
+
+class TestWriteMcpConfigCodexCallsBootstrap:
+    """`write_mcp_config(agent="codex", ...)` must run the auth
+    bootstrap as part of its work, so a single `crew setup` /
+    `crew recover` call leaves codex fully ready."""
+
+    def test_write_mcp_config_codex_writes_auth_when_global_exists(self, tmp_path):
+        fake_home = tmp_path / "fake_home"
+        global_dir = fake_home / ".codex"
+        global_dir.mkdir(parents=True)
+        (global_dir / "auth.json").write_text("{\"x\":1}")
+
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+
+        with patch.dict(os.environ, {"HOME": str(fake_home)}):
+            crew_setup.write_mcp_config(str(worktree), "/db.db", agent="codex")
+
+        # config.toml + auth.json both materialise.
+        assert (worktree / ".codex_local" / "config.toml").exists()
+        assert (worktree / ".codex_local" / "auth.json").exists()
+
+    def test_write_mcp_config_codex_no_auth_when_global_missing(self, tmp_path):
+        fake_home = tmp_path / "fake_home"
+        fake_home.mkdir()
+
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+
+        with patch.dict(os.environ, {"HOME": str(fake_home)}):
+            crew_setup.write_mcp_config(str(worktree), "/db.db", agent="codex")
+
+        # config.toml still written; auth.json silently skipped.
+        assert (worktree / ".codex_local" / "config.toml").exists()
+        assert not (worktree / ".codex_local" / "auth.json").exists()


### PR DESCRIPTION
## Summary

Phase 5 (#113) gave codex/gemini per-worktree MCP configs. Trader-project verification surfaced two follow-ups:

1. **Codex auth re-prompt.** With \`CODEX_HOME=<wt>/.codex_local\`, codex stops falling back to \`~/.codex\` and asks the operator for a fresh OAuth flow on every worktree.
2. **Gemini --yolo skipped shell tools.** With an MCP server registered alongside built-ins, gemini's \`--yolo\` flag was observed to still prompt before \`git\` execution (verified on trader gemini pane).

## Changes

\`setup._bootstrap_codex_auth(codex_home)\` (new):
- Copies \`~/.codex/auth.json\` into \`<wt>/.codex_local/auth.json\` with mode 0600.
- Idempotent (always refreshes from the global file — codex rewrites it on token refresh).
- Silent skip when global is missing.
- Copy, not symlink — codex rewrites in place on refresh, so a symlink would couple unrelated worktrees through inode/mtime.

\`_write_mcp_config_codex(...)\` calls the bootstrap right after writing \`config.toml\`, so a single \`crew setup\` / \`crew recover\` leaves codex fully ready.

\`_AGENT_CMDS["gemini"]\`: \`gemini --yolo\` → \`gemini --approval-mode yolo\`. Same intent ("auto-approve all tools"), but the policy-engine flag is what the engine actually consults consistently.

## Tests

\`tests/unit/test_codex_auth_bootstrap.py\` (5):
- \`_bootstrap_codex_auth\`: copies global auth, preserves 0600 mode, silent-skip on missing global, idempotent (refreshes from global).
- \`write_mcp_config(agent=\"codex\")\` end-to-end: produces both \`config.toml\` and \`auth.json\` when global exists; produces only \`config.toml\` when global is missing.

Full suite: **383/383 passing**.

## Verification on trader

After PR #113 + manual \`cp ~/.codex/auth.json .codex_local/\`, codex/gemini both successfully called \`get_next_task\` via MCP and codex submitted \`review-edaf554b\` via \`submit_result\`. The remaining gemini \"Allow execution of [git]?\" prompt is what \`--approval-mode yolo\` removes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)