### PR TITLE
fix(#115): tester gemini --model gemini-2.5-flash로 변경

### DIFF
--- a/src/agent_crew/setup.py
+++ b/src/agent_crew/setup.py
@@ -14,7 +14,11 @@ _AGENT_CMDS = {
     # bypasses every tool prompt (including shell/git which the legacy
     # ``--yolo`` short flag was observed to miss when an MCP server is
     # registered alongside built-in tools — Issue #110 phase 5b).
-    "gemini": "gemini --approval-mode yolo",
+    # ``--model gemini-2.5-flash``: tester 단계에서 gemini-2.5-pro의 long-context
+    # 응답이 streaming 없이 모델 처리에 머무는 구간이 길어 watchdog 300s
+    # idle 오탐을 자주 일으켰다 (#115). flash는 응답이 가벼워 idle 빈도가
+    # 줄고 테스트 실행/검토 작업 품질엔 영향이 작다.
+    "gemini": "gemini --approval-mode yolo --model gemini-2.5-flash",
 }
 _DEFAULT_CMD = "claude --dangerously-skip-permissions --continue"
 


### PR DESCRIPTION
[agent: claude-cli]

## Summary
- tester(gemini) 명령에 `--model gemini-2.5-flash` 추가
- 기본 gemini-2.5-pro의 long-context 응답이 streaming 없이 모델 처리에 머무는 구간이 길어 watchdog 300s idle 오탐 빈발 (#115)

## 변경
\`\`\`diff
-    \"gemini\": \"gemini --approval-mode yolo\",
+    \"gemini\": \"gemini --approval-mode yolo --model gemini-2.5-flash\",
\`\`\`

## 관찰 근거
alpha_engine L1 sub-2 작업 중 4건 연속 발생:
- A1 (#856 PR) — tester pane 300s idle → auto-fail
- A2 (#857 PR) — reviewer pane도 301s idle 발생
- A3 (#858 PR) — \`--no-tester\` 우회로만 진행 가능
- A4 (#859 PR) — 동일

## Test plan
- [ ] 새 \`crew setup <project>\` 후 \`crew run\` → tester pane이 300s 안에 응답 시작하는지 확인
- [ ] 기존 worktree는 pane 재기동 시 적용

## Refs
- Issue: #115
- Companion idea (이 PR엔 미포함): per-step timeout(\`CREW_TESTER_TIMEOUT\`), heartbeat ping, idle CPU 사용량 fallback

Agent: claude-cli
Mode: bugfix
Tools: gemini-cli 0.39.1