### PR TITLE
fix(#117): prevent self-review/self-test in rate-limit fallback chain

### DIFF
--- a/src/agent_crew/server.py
+++ b/src/agent_crew/server.py
@@ -640,6 +640,17 @@ def create_app(
                     f"from a stale local copy."
                 )
 
+            # Identify which agent actually implemented this task. Prefer the
+            # explicit override (set by upstream fallback), else fall back to
+            # the role's default mapping. Recorded in review_context so the
+            # rate-limit fallback handler can skip it during reviewer
+            # selection (#117 — self-review prevention).
+            impl_ctx = impl_task.context if isinstance(impl_task.context, dict) else {}
+            implementer_agent = (
+                impl_ctx.get("agent_override")
+                or (default_agent_for_role("implementer", pane_map) if pane_map else None)
+            )
+
             # Create review task with same description/branch, reference to impl task.
             # Inherit top-level project from impl task so the cross-project guard works
             # for subsequent hops in the pipeline (review → test).
@@ -656,6 +667,8 @@ def create_app(
                 "prev_task_id": impl_task_id,
                 "pr_number": pr_number,
             }
+            if implementer_agent:
+                review_context["implementer_agent"] = implementer_agent
             review_req = TaskRequest(
                 task_id=f"review-{uuid.uuid4().hex[:8]}",
                 task_type="review",
@@ -691,10 +704,23 @@ def create_app(
             if _resolve_verdict(review_result) != "approve":
                 return
 
+            # Propagate upstream agent identities so review/test fallback can
+            # avoid self-review and self-test (#117).
+            review_ctx = review_task.context if isinstance(review_task.context, dict) else {}
+            implementer_agent = review_ctx.get("implementer_agent")
+            reviewer_agent = (
+                review_ctx.get("agent_override")
+                or (default_agent_for_role("reviewer", pane_map) if pane_map else None)
+            )
+
             # Create test task with same description/branch, reference to review task
             test_context = {
                 "prev_task_id": review_task_id,
             }
+            if implementer_agent:
+                test_context["implementer_agent"] = implementer_agent
+            if reviewer_agent:
+                test_context["reviewer_agent"] = reviewer_agent
             test_req = TaskRequest(
                 task_id=f"test-{uuid.uuid4().hex[:8]}",
                 task_type="test",
@@ -779,6 +805,14 @@ def create_app(
                 or (default_agent_for_role(role, pane_map) if (role and pane_map) else None)
             )
             excluded = list(ctx.get("fallback_excluded") or [])
+            # Self-review/self-test prevention (#117): any upstream agent
+            # already in the lineage (impl→review→test) must be excluded so
+            # the chain doesn't loop the task back to a participant whose
+            # output is being judged.
+            for upstream_key in ("implementer_agent", "reviewer_agent"):
+                upstream = ctx.get(upstream_key)
+                if upstream and upstream not in excluded:
+                    excluded.append(upstream)
             if current_agent and current_agent not in excluded:
                 excluded.append(current_agent)
 

--- a/tests/unit/test_self_review_prevention.py
+++ b/tests/unit/test_self_review_prevention.py
@@ -1,0 +1,219 @@
+"""Self-review/self-test prevention in rate-limit fallback (Issue #117).
+
+When `_auto_fallback_failed_task` reroutes a review or test task because
+the assigned agent hit a rate-limit, the successor must skip any agent
+that already participated upstream in the pipeline:
+
+  - review fallback must skip the impl task's implementer
+  - test fallback must skip both the implementer and the reviewer
+
+To make that decision, `_auto_enqueue_review` and `_auto_enqueue_test`
+record the upstream agent identities into the new task's context
+(`implementer_agent`, `reviewer_agent`). The fallback handler then
+unions those names into the `excluded` list before walking the chain.
+"""
+from fastapi.testclient import TestClient
+
+from agent_crew.server import create_app
+
+
+def _task_payload(task_id, task_type, description="do work", priority=3,
+                  project="", context=None):
+    return {
+        "task_id": task_id,
+        "task_type": task_type,
+        "description": description,
+        "branch": "main",
+        "priority": priority,
+        "context": context or {},
+        "project": project,
+    }
+
+
+def _result_payload(task_id, status="completed", summary="done",
+                    verdict=None, findings=None, pr_number=None):
+    return {
+        "task_id": task_id,
+        "status": status,
+        "summary": summary,
+        "verdict": verdict,
+        "findings": findings or [],
+        "pr_number": pr_number,
+    }
+
+
+class RecordingPush:
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, pane_id, text):
+        self.calls.append((pane_id, text))
+
+
+# Full 3-agent pane map: each role + agent share a pane (matches `crew setup`).
+PANE_MAP = {
+    "implementer": "%100", "claude": "%100",
+    "reviewer": "%200", "codex": "%200",
+    "tester": "%300", "gemini": "%300",
+}
+
+
+# ---------------------------------------------------------------------------
+# auto_enqueue_review records implementer
+# ---------------------------------------------------------------------------
+
+
+class TestAutoEnqueueReviewRecordsImplementer:
+    def test_default_implementer_is_claude(self, tmp_db):
+        """Impl task without agent_override → review_context records claude."""
+        push = RecordingPush()
+        app = create_app(
+            db_path=tmp_db, pane_map=PANE_MAP, port=8100, push_fn=push
+        )
+        with TestClient(app) as client:
+            client.post("/tasks", json=_task_payload("impl-001", "implement"))
+            client.post(
+                "/tasks/impl-001/result", json=_result_payload("impl-001")
+            )
+            tasks = client.get("/tasks").json()
+            reviews = [t for t in tasks if t["task_type"] == "review"]
+            assert len(reviews) == 1
+            assert reviews[0]["context"].get("implementer_agent") == "claude"
+
+    def test_override_implementer_is_recorded(self, tmp_db):
+        """Impl task with agent_override=gemini → review records gemini."""
+        push = RecordingPush()
+        app = create_app(
+            db_path=tmp_db, pane_map=PANE_MAP, port=8100, push_fn=push
+        )
+        with TestClient(app) as client:
+            ctx = {"agent_override": "gemini"}
+            client.post(
+                "/tasks",
+                json=_task_payload("impl-002", "implement", context=ctx),
+            )
+            client.post(
+                "/tasks/impl-002/result", json=_result_payload("impl-002")
+            )
+            tasks = client.get("/tasks").json()
+            reviews = [t for t in tasks if t["task_type"] == "review"]
+            assert reviews[0]["context"].get("implementer_agent") == "gemini"
+
+
+# ---------------------------------------------------------------------------
+# auto_enqueue_test records both implementer and reviewer
+# ---------------------------------------------------------------------------
+
+
+class TestAutoEnqueueTestRecordsBothAgents:
+    def test_full_pipeline_records_implementer_and_reviewer(self, tmp_db):
+        """impl(claude) → review(codex approve) → test must inherit
+        implementer_agent=claude and reviewer_agent=codex."""
+        push = RecordingPush()
+        app = create_app(
+            db_path=tmp_db, pane_map=PANE_MAP, port=8100, push_fn=push
+        )
+        with TestClient(app) as client:
+            client.post("/tasks", json=_task_payload("impl-003", "implement"))
+            client.post(
+                "/tasks/impl-003/result", json=_result_payload("impl-003")
+            )
+            tasks = client.get("/tasks").json()
+            review = [t for t in tasks if t["task_type"] == "review"][0]
+            client.post(
+                f"/tasks/{review['task_id']}/result",
+                json=_result_payload(review["task_id"], verdict="approve"),
+            )
+            tasks2 = client.get("/tasks").json()
+            tests = [t for t in tasks2 if t["task_type"] == "test"]
+            assert len(tests) == 1
+            test_ctx = tests[0]["context"]
+            assert test_ctx.get("implementer_agent") == "claude"
+            assert test_ctx.get("reviewer_agent") == "codex"
+
+
+# ---------------------------------------------------------------------------
+# Fallback skips upstream agents
+# ---------------------------------------------------------------------------
+
+
+class TestReviewFallbackSkipsImplementer:
+    def test_codex_review_fails_claude_skipped_picks_gemini(self, tmp_db):
+        """Review chain ['codex','claude','gemini']. codex (current) hits
+        rate-limit and claude is the implementer → fallback must pick gemini."""
+        push = RecordingPush()
+        app = create_app(
+            db_path=tmp_db, pane_map=PANE_MAP, port=8100, push_fn=push
+        )
+        with TestClient(app) as client:
+            ctx = {"agent_override": "codex", "implementer_agent": "claude"}
+            client.post(
+                "/tasks",
+                json=_task_payload("rev-001", "review", context=ctx),
+            )
+            client.post(
+                "/tasks/rev-001/result",
+                json=_result_payload(
+                    "rev-001", status="failed", summary="usage limit"
+                ),
+            )
+            tasks = client.get("/tasks").json()
+            fb = [
+                t for t in tasks
+                if t["task_id"].startswith("fallback-rev-001")
+            ]
+            assert len(fb) == 1, (
+                "expected exactly one fallback task; got "
+                f"{[t['task_id'] for t in fb]}"
+            )
+            new_ctx = fb[0]["context"]
+            assert new_ctx["agent_override"] == "gemini"
+            excluded = new_ctx.get("fallback_excluded", [])
+            assert "codex" in excluded
+            assert "claude" in excluded
+            # implementer_agent must propagate so subsequent fallbacks still
+            # know who not to route back to.
+            assert new_ctx.get("implementer_agent") == "claude"
+
+
+class TestTestFallbackSkipsImplementerAndReviewer:
+    def test_gemini_test_fails_implementer_and_reviewer_excluded_escalates(
+        self, tmp_db
+    ):
+        """Test chain ['gemini','codex','claude']. gemini (current) hits
+        rate-limit; codex was the reviewer; claude was the implementer →
+        chain exhausted → no fallback task, escalation gate created."""
+        push = RecordingPush()
+        app = create_app(
+            db_path=tmp_db, pane_map=PANE_MAP, port=8100, push_fn=push
+        )
+        with TestClient(app) as client:
+            ctx = {
+                "agent_override": "gemini",
+                "implementer_agent": "claude",
+                "reviewer_agent": "codex",
+            }
+            client.post(
+                "/tasks",
+                json=_task_payload("test-001", "test", context=ctx),
+            )
+            client.post(
+                "/tasks/test-001/result",
+                json=_result_payload(
+                    "test-001",
+                    status="failed",
+                    summary="quota exceeded",
+                ),
+            )
+            tasks = client.get("/tasks").json()
+            fb = [
+                t for t in tasks
+                if t["task_id"].startswith("fallback-test-001")
+            ]
+            assert fb == [], (
+                "expected zero fallback tasks (chain exhausted); got "
+                f"{[t['task_id'] for t in fb]}"
+            )
+            gates = client.get("/gates/pending").json()
+            esc = [g for g in gates if g.get("type") == "escalation"]
+            assert len(esc) >= 1


### PR DESCRIPTION
Closes #117.

## Summary
- Records `implementer_agent` (and `reviewer_agent` for tests) into auto-enqueued task contexts so the rate-limit fallback handler can skip upstream participants when picking a successor.
- Without this, a review task whose codex reviewer hits a rate-limit gets rerouted to the next chain entry — frequently the impl task's claude — making claude review its own code.

## Changes
- `_auto_enqueue_review` (server.py): captures impl task's agent into `review_context["implementer_agent"]`.
- `_auto_enqueue_test` (server.py): propagates `implementer_agent` and captures the reviewer into `test_context["reviewer_agent"]`.
- `_auto_fallback_failed_task` (server.py): extends `excluded` with any upstream agents recorded in the failed task's context before walking the chain.

## Test plan
- [x] New tests in `tests/unit/test_self_review_prevention.py` cover all three insertion points + the chain-exhausted case where both upstream agents leave only the just-failed agent → escalation.
- [x] Full unit suite: 388 passed, 0 regressions.
- [x] No new lint warnings introduced (pre-existing F541s in unrelated lines untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)