### PR TITLE
refactor(#123): transport-agnostic stage cascade hooks

### DIFF
--- a/src/agent_crew/mcp_server.py
+++ b/src/agent_crew/mcp_server.py
@@ -34,6 +34,12 @@ try:
 except ImportError:  # pragma: no cover — surfaced loud at import time
     FastMCP = None  # type: ignore
 
+from agent_crew.loop import _resolve_verdict
+from agent_crew.pipeline import (
+    auto_enqueue_review,
+    auto_enqueue_test,
+    auto_fallback_failed_task,
+)
 from agent_crew.protocol import TaskRequest, TaskResult
 from agent_crew.queue import TaskQueue
 
@@ -162,6 +168,18 @@ def build_mcp_server(
             task_type = queue.submit_result(task_id, result)
         except ValueError as e:
             return {"acknowledged": False, "error": str(e)}
+
+        # Stage cascade — same hooks as the HTTP path so the pipeline does
+        # not stall after the first stage when an agent uses MCP-only
+        # delivery (#123). Push side-effects are not part of the cascade
+        # contract; agents pull tasks themselves on the MCP loop.
+        if task_type == "implement" and result.status == "completed":
+            auto_enqueue_review(queue, task_id, pr_number=result.pr_number)
+        elif task_type == "review" and _resolve_verdict(result) == "approve":
+            auto_enqueue_test(queue, task_id)
+        if result.status == "failed":
+            auto_fallback_failed_task(queue, task_id, result, task_type)
+
         return {"acknowledged": True, "task_id": task_id, "task_type": task_type}
 
     @mcp.tool()

--- a/src/agent_crew/pipeline.py
+++ b/src/agent_crew/pipeline.py
@@ -1,0 +1,290 @@
+"""Stage cascade hooks — transport-agnostic (Issue #123).
+
+When a task gets a result submitted, three follow-up flows may fire:
+
+  1. ``auto_enqueue_review``           impl ✓  → enqueue a review task
+  2. ``auto_enqueue_test``             review approve → enqueue a test task
+  3. ``auto_fallback_failed_task``     rate-limit ✗ → reroute to next agent
+
+Both transports — HTTP ``submit_result`` and MCP ``submit_result`` — must
+trigger these so the pipeline doesn't stall after the first stage when an
+agent is on the MCP-only path (#106 cutover prerequisite).
+
+The helpers operate on a ``TaskQueue`` and never touch tmux. Push
+notifications (paste-buffer + send-keys) are an HTTP-side concern that
+remains in ``server.py``: ``_auto_enqueue_review`` etc. wrap these
+functions, run them first, and *then* call ``_try_push_next``.
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Optional
+
+from agent_crew.fallback import (
+    default_agent_for_role,
+    has_rate_limit_signal,
+    load_fallback_chains,
+    next_agent,
+)
+from agent_crew.loop import _resolve_verdict
+from agent_crew.notify import notify_telegram
+from agent_crew.protocol import GateRequest, TaskRequest, TaskResult
+from agent_crew.queue import TaskQueue, _TYPE_TO_ROLE
+
+logger = logging.getLogger(__name__)
+
+
+def auto_enqueue_review(
+    queue: TaskQueue,
+    impl_task_id: str,
+    pr_number: Optional[int] = None,
+    *,
+    pane_map: Optional[dict] = None,
+    server_project: Optional[str] = None,
+) -> Optional[str]:
+    """Create the review task that follows a completed impl task.
+
+    Returns the new review task_id, or ``None`` when no review is created
+    (cross-project guard, missing impl task, exception). Callers swallow
+    the None — auto-enqueue must never crash a result submission.
+    """
+    try:
+        impl_tasks = [t for t in queue.list_tasks() if t.task_id == impl_task_id]
+        if not impl_tasks:
+            return None
+        impl_task = impl_tasks[0]
+
+        # Cross-project guard: if the impl task carries a top-level project tag
+        # and the server was started for a different project, skip auto-review
+        # to prevent misrouting tasks across project queues.
+        impl_project = impl_task.project
+        if impl_project and server_project and impl_project != server_project:
+            logger.warning(
+                f"auto_enqueue_review: skipping cross-project review — "
+                f"impl project={impl_project!r}, server project={server_project!r}"
+            )
+            return None
+
+        # Build a freshness directive that is unambiguous about reviewing
+        # the live PR HEAD, not a stale local copy or an earlier round.
+        if pr_number is not None:
+            pr_directive = (
+                f"\n\nFRESHNESS: review PR #{pr_number} at its CURRENT head. "
+                f"Run `gh pr diff {pr_number}` (and/or "
+                f"`gh pr view {pr_number} --json commits`) FIRST. Do NOT "
+                f"reuse line numbers from any earlier review round — they "
+                f"reference the prior commit. Pin every finding to the "
+                f"latest commit's file:line."
+            )
+        else:
+            pr_directive = (
+                f"\n\nFRESHNESS: identify the PR for branch "
+                f"{impl_task.branch!r} via `gh pr list --head "
+                f"{impl_task.branch}`, then `gh pr diff <num>` to fetch "
+                f"the live head before pinning findings. Do NOT review "
+                f"from a stale local copy."
+            )
+
+        # Identify which agent actually implemented this task. Prefer the
+        # explicit override (set by upstream fallback), else fall back to
+        # the role's default mapping. Recorded so the rate-limit fallback
+        # handler can skip it during reviewer selection (#117 — self-review
+        # prevention).
+        impl_ctx = impl_task.context if isinstance(impl_task.context, dict) else {}
+        implementer_agent = (
+            impl_ctx.get("agent_override")
+            or (default_agent_for_role("implementer", pane_map) if pane_map else None)
+        )
+
+        review_context = {
+            "checklist_layers": ["test_quality", "code_quality", "business_gap"],
+            "reviewer_rejects_happy_path_only": True,
+            "instructions": (
+                "3-layer review: "
+                "1) test_quality — coverage, edge cases, mocks; "
+                "2) code_quality — naming, error handling, SOLID; "
+                "3) business_gap — requirements met, logging, observability."
+                + pr_directive
+            ),
+            "prev_task_id": impl_task_id,
+            "pr_number": pr_number,
+        }
+        if implementer_agent:
+            review_context["implementer_agent"] = implementer_agent
+
+        review_id = f"review-{uuid.uuid4().hex[:8]}"
+        review_req = TaskRequest(
+            task_id=review_id,
+            task_type="review",  # type: ignore[arg-type]
+            description=impl_task.description,
+            branch=impl_task.branch,
+            context=review_context,
+            project=impl_project,
+        )
+        queue.enqueue(review_req)
+        return review_id
+    except Exception as e:
+        logger.warning(f"auto_enqueue_review: unexpected error: {e}")
+        return None
+
+
+def auto_enqueue_test(
+    queue: TaskQueue,
+    review_task_id: str,
+    *,
+    pane_map: Optional[dict] = None,
+) -> Optional[str]:
+    """Create the test task that follows an approved review.
+
+    Returns the new test task_id, or ``None`` when no test is created
+    (review missing/rejected, exception).
+    """
+    try:
+        review_tasks = [t for t in queue.list_tasks() if t.task_id == review_task_id]
+        if not review_tasks:
+            return None
+        review_task = review_tasks[0]
+
+        # Use the defensive verdict resolver from loop.py so reviewers that
+        # post `verdict=null` with empty findings still trip the auto-test
+        # (#100).
+        review_result = queue.get_result(review_task_id)
+        if not review_result:
+            return None
+        if _resolve_verdict(review_result) != "approve":
+            return None
+
+        # Propagate upstream agent identities so review/test fallback can
+        # avoid self-review and self-test (#117).
+        review_ctx = review_task.context if isinstance(review_task.context, dict) else {}
+        implementer_agent = review_ctx.get("implementer_agent")
+        reviewer_agent = (
+            review_ctx.get("agent_override")
+            or (default_agent_for_role("reviewer", pane_map) if pane_map else None)
+        )
+
+        test_context = {"prev_task_id": review_task_id}
+        if implementer_agent:
+            test_context["implementer_agent"] = implementer_agent
+        if reviewer_agent:
+            test_context["reviewer_agent"] = reviewer_agent
+
+        test_id = f"test-{uuid.uuid4().hex[:8]}"
+        test_req = TaskRequest(
+            task_id=test_id,
+            task_type="test",  # type: ignore[arg-type]
+            description=review_task.description,
+            branch=review_task.branch,
+            context=test_context,
+        )
+        queue.enqueue(test_req)
+        return test_id
+    except Exception as e:
+        logger.warning(f"auto_enqueue_test: unexpected error: {e}")
+        return None
+
+
+def auto_fallback_failed_task(
+    queue: TaskQueue,
+    task_id: str,
+    result: TaskResult,
+    task_type: str,
+    *,
+    pane_map: Optional[dict] = None,
+    state_path: Optional[str] = None,
+    fallback_disabled: bool = False,
+) -> bool:
+    """Reroute a rate-limit-shaped failure to the next agent in the chain.
+
+    Returns ``True`` when fallback handled the task — caller should skip
+    auto-retry. ``False`` means caller should fall through to its normal
+    retry path. On chain exhaustion, opens an ``escalation`` gate and
+    sends a Telegram alert (best-effort).
+    """
+    if fallback_disabled:
+        return False
+    if not has_rate_limit_signal(result.summary, result.findings):
+        return False
+
+    try:
+        tasks = [t for t in queue.list_tasks() if t.task_id == task_id]
+        if not tasks:
+            return False
+        original = tasks[0]
+        ctx = dict(original.context) if isinstance(original.context, dict) else {}
+
+        role = _TYPE_TO_ROLE.get(task_type)
+        current_agent = (
+            ctx.get("agent_override")
+            or (default_agent_for_role(role, pane_map) if (role and pane_map) else None)
+        )
+        excluded = list(ctx.get("fallback_excluded") or [])
+        # Self-review/self-test prevention (#117): any upstream agent
+        # already in the lineage (impl→review→test) must be excluded so
+        # the chain doesn't loop the task back to a participant whose
+        # output is being judged.
+        for upstream_key in ("implementer_agent", "reviewer_agent"):
+            upstream = ctx.get(upstream_key)
+            if upstream and upstream not in excluded:
+                excluded.append(upstream)
+        if current_agent and current_agent not in excluded:
+            excluded.append(current_agent)
+
+        chains = load_fallback_chains(state_path)
+        successor = next_agent(task_type, current_agent, excluded, chains)
+
+        if successor is None:
+            logger.warning(
+                f"auto_fallback: chain exhausted for {task_id} "
+                f"(task_type={task_type}, excluded={excluded}). Escalating."
+            )
+            msg = (
+                f"agent_crew rate-limit fallback exhausted\n"
+                f"task_id: {task_id}\n"
+                f"task_type: {task_type}\n"
+                f"tried agents: {', '.join(excluded) or '(none)'}\n"
+                f"last summary: {(result.summary or '')[:200]}"
+            )
+            try:
+                queue.create_gate(
+                    GateRequest(
+                        id=f"escalation-{task_id}-{uuid.uuid4().hex[:4]}",
+                        type="escalation",
+                        message=msg,
+                        status="pending",
+                    )
+                )
+            except Exception as e:
+                logger.warning(f"auto_fallback: failed to create escalation gate: {e}")
+            try:
+                notify_telegram(msg)
+            except Exception:
+                pass
+            return True
+
+        new_ctx = dict(ctx)
+        new_ctx["agent_override"] = successor
+        new_ctx["fallback_excluded"] = excluded
+        new_ctx["fallback_from_task_id"] = task_id
+        try:
+            fallback_req = TaskRequest(
+                task_id=f"fallback-{task_id}-{uuid.uuid4().hex[:4]}",
+                task_type=task_type,  # type: ignore[arg-type]
+                description=original.description,
+                branch=original.branch,
+                priority=original.priority,
+                context=new_ctx,
+            )
+            queue.enqueue(fallback_req)
+            logger.info(
+                f"auto_fallback: rerouted {task_id} -> {successor} "
+                f"(excluded={excluded})"
+            )
+            return True
+        except Exception as e:
+            logger.warning(f"auto_fallback: enqueue failed for {task_id}: {e}")
+            return False
+    except Exception as e:
+        logger.warning(f"auto_fallback: unexpected error for {task_id}: {e}")
+        return False

--- a/src/agent_crew/server.py
+++ b/src/agent_crew/server.py
@@ -14,14 +14,12 @@ from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 
 from agent_crew.anomaly import check_wrong_repo
-from agent_crew.fallback import (
-    default_agent_for_role,
-    has_rate_limit_signal,
-    load_fallback_chains,
-    next_agent,
-)
 from agent_crew.loop import _resolve_verdict
-from agent_crew.notify import notify_telegram
+from agent_crew.pipeline import (
+    auto_enqueue_review as _pipeline_auto_enqueue_review,
+    auto_enqueue_test as _pipeline_auto_enqueue_test,
+    auto_fallback_failed_task as _pipeline_auto_fallback_failed_task,
+)
 from agent_crew.protocol import GateRequest, TaskRequest, TaskResult
 from agent_crew.queue import TaskQueue, _ROLE_TO_TYPE, _TYPE_TO_ROLE
 
@@ -594,146 +592,33 @@ def create_app(
         impl_task_id: str,
         pr_number: Optional[int] = None,
     ) -> None:
-        """Auto-enqueue a review task when an impl task completes.
-        This ensures review is triggered independently of CLI timeout.
+        """HTTP-side wrapper: run the transport-agnostic cascade then push.
 
-        ``pr_number`` is the PR opened by the impl run (if any). It's threaded
-        into both the review task context and the rendered instructions so
-        the reviewer always pins findings to the live PR head commit instead
-        of an earlier round's diff (issue #86).
+        The body of the cascade lives in ``agent_crew.pipeline`` so the MCP
+        ``submit_result`` path can fire the same hook (#123). This wrapper
+        only adds the tmux push side-effect, which the MCP path skips —
+        agents on the MCP loop pull tasks themselves.
         """
-        try:
-            # Get the original impl task to extract description and branch
-            impl_tasks = [t for t in q().list_tasks() if t.task_id == impl_task_id]
-            if not impl_tasks:
-                return
-            impl_task = impl_tasks[0]
-
-            # Cross-project guard: if the impl task carries a top-level project tag
-            # and the server was started for a different project, skip auto-review to
-            # prevent misrouting tasks across project queues.
-            impl_project = impl_task.project  # top-level field, typed
-            if impl_project and project and impl_project != project:
-                logger.warning(
-                    f"_auto_enqueue_review: skipping cross-project review — "
-                    f"impl project={impl_project!r}, server project={project!r}"
-                )
-                return
-
-            # Build a freshness directive that is unambiguous about reviewing
-            # the live PR HEAD, not a stale local copy or an earlier round.
-            if pr_number is not None:
-                pr_directive = (
-                    f"\n\nFRESHNESS: review PR #{pr_number} at its CURRENT head. "
-                    f"Run `gh pr diff {pr_number}` (and/or "
-                    f"`gh pr view {pr_number} --json commits`) FIRST. Do NOT "
-                    f"reuse line numbers from any earlier review round — they "
-                    f"reference the prior commit. Pin every finding to the "
-                    f"latest commit's file:line."
-                )
-            else:
-                pr_directive = (
-                    f"\n\nFRESHNESS: identify the PR for branch "
-                    f"{impl_task.branch!r} via `gh pr list --head "
-                    f"{impl_task.branch}`, then `gh pr diff <num>` to fetch "
-                    f"the live head before pinning findings. Do NOT review "
-                    f"from a stale local copy."
-                )
-
-            # Identify which agent actually implemented this task. Prefer the
-            # explicit override (set by upstream fallback), else fall back to
-            # the role's default mapping. Recorded in review_context so the
-            # rate-limit fallback handler can skip it during reviewer
-            # selection (#117 — self-review prevention).
-            impl_ctx = impl_task.context if isinstance(impl_task.context, dict) else {}
-            implementer_agent = (
-                impl_ctx.get("agent_override")
-                or (default_agent_for_role("implementer", pane_map) if pane_map else None)
-            )
-
-            # Create review task with same description/branch, reference to impl task.
-            # Inherit top-level project from impl task so the cross-project guard works
-            # for subsequent hops in the pipeline (review → test).
-            review_context = {
-                "checklist_layers": ["test_quality", "code_quality", "business_gap"],
-                "reviewer_rejects_happy_path_only": True,
-                "instructions": (
-                    "3-layer review: "
-                    "1) test_quality — coverage, edge cases, mocks; "
-                    "2) code_quality — naming, error handling, SOLID; "
-                    "3) business_gap — requirements met, logging, observability."
-                    + pr_directive
-                ),
-                "prev_task_id": impl_task_id,
-                "pr_number": pr_number,
-            }
-            if implementer_agent:
-                review_context["implementer_agent"] = implementer_agent
-            review_req = TaskRequest(
-                task_id=f"review-{uuid.uuid4().hex[:8]}",
-                task_type="review",
-                description=impl_task.description,
-                branch=impl_task.branch,
-                context=review_context,
-                project=impl_project,  # top-level field propagated
-            )
-            q().enqueue(review_req)
-            # Try to push the newly enqueued review task to reviewer pane
+        review_id = _pipeline_auto_enqueue_review(
+            q(),
+            impl_task_id,
+            pr_number,
+            pane_map=pane_map,
+            server_project=project,
+        )
+        if review_id:
             _try_push_next("reviewer")
-        except Exception:
-            # Silently fail auto-enqueue — don't crash the result submission
-            pass
 
     def _auto_enqueue_test(review_task_id: str) -> None:
-        """Auto-enqueue a test task when a review task is approved.
-        This ensures testing is triggered independently of CLI timeout."""
-        try:
-            # Get the review task to extract description and branch
-            review_tasks = [t for t in q().list_tasks() if t.task_id == review_task_id]
-            if not review_tasks:
-                return
-            review_task = review_tasks[0]
-
-            # Get the review result to confirm it was approved. Use the
-            # defensive verdict resolver from loop.py so reviewers that
-            # post `verdict=null` with empty findings still trip the
-            # auto-test (#100).
-            review_result = q().get_result(review_task_id)
-            if not review_result:
-                return
-            if _resolve_verdict(review_result) != "approve":
-                return
-
-            # Propagate upstream agent identities so review/test fallback can
-            # avoid self-review and self-test (#117).
-            review_ctx = review_task.context if isinstance(review_task.context, dict) else {}
-            implementer_agent = review_ctx.get("implementer_agent")
-            reviewer_agent = (
-                review_ctx.get("agent_override")
-                or (default_agent_for_role("reviewer", pane_map) if pane_map else None)
-            )
-
-            # Create test task with same description/branch, reference to review task
-            test_context = {
-                "prev_task_id": review_task_id,
-            }
-            if implementer_agent:
-                test_context["implementer_agent"] = implementer_agent
-            if reviewer_agent:
-                test_context["reviewer_agent"] = reviewer_agent
-            test_req = TaskRequest(
-                task_id=f"test-{uuid.uuid4().hex[:8]}",
-                task_type="test",
-                description=review_task.description,
-                branch=review_task.branch,
-                context=test_context,
-            )
-            q().enqueue(test_req)
-            # Try to push the newly enqueued test task to tester pane
+        """HTTP-side wrapper: run the transport-agnostic cascade then push.
+        See ``_auto_enqueue_review`` for the rationale (#123)."""
+        test_id = _pipeline_auto_enqueue_test(
+            q(),
+            review_task_id,
+            pane_map=pane_map,
+        )
+        if test_id:
             _try_push_next("tester")
-        except Exception:
-            # Silently fail auto-enqueue — don't crash the result submission
-            pass
 
     _MAX_RETRIES = 2  # Maximum retry attempts per task
 
@@ -779,103 +664,28 @@ def create_app(
         result: TaskResult,
         task_type: str,
     ) -> bool:
-        """If the failure is rate-limit-shaped, reroute to the next agent in
-        the fallback chain. Returns True when fallback handled the task
-        (caller should skip auto_retry); False when caller should fall through
-        to the normal retry path.
+        """HTTP-side wrapper around the transport-agnostic fallback hook.
 
-        On chain exhaustion, opens an ``escalation`` gate and tries to send a
-        Telegram alert via the #79 helper (best-effort).
+        The decision logic moved to ``agent_crew.pipeline.auto_fallback_failed_task``
+        so MCP can call the same path (#123). Push side-effect stays
+        HTTP-only — when fallback enqueues a successor task, nudge that
+        role's pane.
         """
-        if fallback_disabled:
-            return False
-        if not has_rate_limit_signal(result.summary, result.findings):
-            return False
-
-        try:
-            tasks = [t for t in q().list_tasks() if t.task_id == task_id]
-            if not tasks:
-                return False
-            original = tasks[0]
-            ctx = dict(original.context) if isinstance(original.context, dict) else {}
-
+        handled = _pipeline_auto_fallback_failed_task(
+            q(),
+            task_id,
+            result,
+            task_type,
+            pane_map=pane_map,
+            state_path=state_path,
+            fallback_disabled=bool(fallback_disabled),
+        )
+        if handled:
             role = _TYPE_TO_ROLE.get(task_type)
-            current_agent = (
-                ctx.get("agent_override")
-                or (default_agent_for_role(role, pane_map) if (role and pane_map) else None)
-            )
-            excluded = list(ctx.get("fallback_excluded") or [])
-            # Self-review/self-test prevention (#117): any upstream agent
-            # already in the lineage (impl→review→test) must be excluded so
-            # the chain doesn't loop the task back to a participant whose
-            # output is being judged.
-            for upstream_key in ("implementer_agent", "reviewer_agent"):
-                upstream = ctx.get(upstream_key)
-                if upstream and upstream not in excluded:
-                    excluded.append(upstream)
-            if current_agent and current_agent not in excluded:
-                excluded.append(current_agent)
-
-            chains = load_fallback_chains(state_path)
-            successor = next_agent(task_type, current_agent, excluded, chains)
-
-            if successor is None:
-                # Chain exhausted — escalate.
-                logger.warning(
-                    f"_auto_fallback: chain exhausted for {task_id} "
-                    f"(task_type={task_type}, excluded={excluded}). Escalating."
-                )
-                msg = (
-                    f"agent_crew rate-limit fallback exhausted\n"
-                    f"task_id: {task_id}\n"
-                    f"task_type: {task_type}\n"
-                    f"tried agents: {', '.join(excluded) or '(none)'}\n"
-                    f"last summary: {(result.summary or '')[:200]}"
-                )
-                try:
-                    q().create_gate(
-                        GateRequest(
-                            id=f"escalation-{task_id}-{uuid.uuid4().hex[:4]}",
-                            type="escalation",
-                            message=msg,
-                            status="pending",
-                        )
-                    )
-                except Exception as e:
-                    logger.warning(f"_auto_fallback: failed to create escalation gate: {e}")
-                try:
-                    notify_telegram(msg)
-                except Exception:
-                    pass
-                return True
-
-            new_ctx = dict(ctx)
-            new_ctx["agent_override"] = successor
-            new_ctx["fallback_excluded"] = excluded
-            new_ctx["fallback_from_task_id"] = task_id
-            try:
-                fallback_req = TaskRequest(
-                    task_id=f"fallback-{task_id}-{uuid.uuid4().hex[:4]}",
-                    task_type=task_type,  # type: ignore
-                    description=original.description,
-                    branch=original.branch,
-                    priority=original.priority,
-                    context=new_ctx,
-                )
-                q().enqueue(fallback_req)
-                logger.info(
-                    f"_auto_fallback: rerouted {task_id} -> {successor} "
-                    f"(excluded={excluded})"
-                )
-                if role:
-                    _try_push_next(role)
-                return True
-            except Exception as e:
-                logger.warning(f"_auto_fallback: enqueue failed for {task_id}: {e}")
-                return False
-        except Exception as e:
-            logger.warning(f"_auto_fallback: unexpected error for {task_id}: {e}")
-            return False
+            if role:
+                # No-op when no successor was enqueued (escalation path).
+                _try_push_next(role)
+        return handled
 
     @app.get("/health")
     def health():

--- a/tests/integration/test_http_mcp_parity.py
+++ b/tests/integration/test_http_mcp_parity.py
@@ -233,21 +233,13 @@ class TestSubmitResultParity:
         }
         assert snap_a == snap_b
 
-    @pytest.mark.xfail(
-        reason=(
-            "Known parity gap: HTTP submit_result auto-enqueues the next "
-            "stage (impl→review, review→test) via _auto_enqueue_review / "
-            "_auto_enqueue_test, which live inside create_app. MCP "
-            "submit_result calls queue.submit_result directly and skips "
-            "those hooks, so the pipeline stalls after the first stage if "
-            "an agent only uses MCP. Must be resolved before #119 cutover. "
-            "Tracking: #123."
-        ),
-        strict=True,
-    )
     def test_completed_impl_auto_enqueues_review_on_both_sides(
         self, parity_pair, tmp_path
     ):
+        """Cascade hook parity (#123 closed): both transports now run the
+        same `pipeline.auto_enqueue_review` after `submit_result`, so an
+        MCP-only agent sees the review task land just like the HTTP path.
+        Was strict-xfail before #123."""
         http_client, _, db_a = parity_pair
         _enqueue_task(db_a, "p-cascade-1")
         http_client.get("/tasks/next", params={"role": "implementer"})

--- a/tests/unit/test_server_fallback.py
+++ b/tests/unit/test_server_fallback.py
@@ -108,9 +108,11 @@ def test_u_fb03_chain_exhaustion_creates_escalation_gate(tmp_db):
     notify_calls: list = []
 
     # Patch notify_telegram to capture the call without going to the network.
-    import agent_crew.server as server_mod
-    original_notify = server_mod.notify_telegram
-    server_mod.notify_telegram = lambda msg, **kw: (notify_calls.append(msg), True)[1]
+    # The escalation hook moved into agent_crew.pipeline as part of #123;
+    # patch that module's symbol so the lambda actually intercepts the call.
+    import agent_crew.pipeline as pipeline_mod
+    original_notify = pipeline_mod.notify_telegram
+    pipeline_mod.notify_telegram = lambda msg, **kw: (notify_calls.append(msg), True)[1]
     try:
         app = _make_app(tmp_db, push_calls=push_calls)
         with TestClient(app) as client:
@@ -127,7 +129,7 @@ def test_u_fb03_chain_exhaustion_creates_escalation_gate(tmp_db):
             )
             client.post(f"/tasks/{fb2.task_id}/result", json=_result(fb2.task_id, summary="usage limit"))
     finally:
-        server_mod.notify_telegram = original_notify
+        pipeline_mod.notify_telegram = original_notify
 
     # No 4th fallback enqueued.
     fallback_tasks = [


### PR DESCRIPTION
Closes #123. Unblocks #119 cutover.

## Summary
Extract `_auto_enqueue_review` / `_auto_enqueue_test` / `_auto_fallback_failed_task` from `create_app`'s closure into a new `agent_crew.pipeline` module so MCP `submit_result` fires the same cascade as HTTP. Push side-effects (tmux paste-buffer + send-keys) stay HTTP-only — MCP agents pull tasks themselves on the loop, so helpers return the new task id and HTTP wrappers call `_try_push_next` after a successful enqueue.

## Before / after

| Path | impl ✓ → review | review approve → test | rate-limit fail → reroute |
|------|-----------------|-----------------------|---------------------------|
| HTTP submit_result (before) | ✓ | ✓ | ✓ |
| MCP submit_result (before) | ✗ | ✗ | ✗ |
| HTTP submit_result (after)  | ✓ | ✓ | ✓ |
| MCP submit_result (after)   | ✓ | ✓ | ✓ |

## Files
- `src/agent_crew/pipeline.py` (new, 290 lines) — three pure helpers, no tmux dependency.
- `src/agent_crew/server.py` — three thin wrappers that call pipeline + push. Net -250 lines.
- `src/agent_crew/mcp_server.py` — `submit_result` now invokes the cascade after `queue.submit_result`.
- `tests/integration/test_http_mcp_parity.py` — strict-xfail removed; cascade test now passes as a regular case.
- `tests/unit/test_server_fallback.py` — patches `pipeline.notify_telegram` instead of `server.notify_telegram` (target moved).

## Test plan
- [x] Full unit suite: 388 passed, 0 regressions
- [x] Parity suite: 13 passed (was 12 + 1 strict-xfail)
- [x] No new ruff warnings introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)