### PR TITLE
feat(#122): per-worktree PostCompact hook for claude task-loop recovery

### DIFF
--- a/src/agent_crew/setup.py
+++ b/src/agent_crew/setup.py
@@ -233,8 +233,82 @@ def _mcp_python_invocation() -> tuple[str, list[str], str]:
     return interpreter, args, pythonpath
 
 
+def _write_postcompact_hook_claude(
+    worktree_path: str,
+    *,
+    agent: str,
+    role: str,
+) -> str:
+    """Drop a per-worktree PostCompact hook into ``.claude/settings.local.json``
+    so Claude Code reinjects the compact task-loop prompt after ``/compact``.
+
+    Without this, the long task-loop system prompt — which tells the agent
+    to keep calling ``get_next_task`` — gets dropped at compaction and the
+    pull loop stalls until the operator manually re-prompts. The hook
+    runs ``build_task_loop_prompt_compact(agent, role)`` and emits the
+    Claude Code ``additionalContext`` payload that re-establishes the loop
+    in one turn (Issue #122).
+
+    Returns the absolute path to the settings file. Idempotent — overwrites
+    any prior version with fresh interpreter / PYTHONPATH values so the
+    hook keeps working across env changes.
+    """
+    interpreter, _, pythonpath = _mcp_python_invocation()
+
+    # Single-line python invocation; we go through `-c` so we don't have
+    # to ship a separate hook script and risk it falling out of sync.
+    # Prompt contains no shell-special chars but we still pipe via JSON to
+    # be safe.
+    snippet = (
+        "import json; "
+        "from agent_crew.prompts.task_loop import build_task_loop_prompt_compact; "
+        "print(json.dumps({"
+        "'hookSpecificOutput': {"
+        "'hookEventName': 'PostCompact', "
+        f"'additionalContext': build_task_loop_prompt_compact({agent!r}, {role!r})"
+        "}}))"
+    )
+    # Prepend the env so the subprocess Claude Code spawns picks up our
+    # PYTHONPATH (Claude Code does not inherit per-worktree mcp env into
+    # hook commands).
+    command = (
+        f'PYTHONPATH="{pythonpath}" "{interpreter}" -c "{snippet}"'
+    )
+
+    settings = {
+        "hooks": {
+            "PostCompact": [
+                {
+                    "matcher": "",
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": command,
+                            "timeout": 10,
+                        }
+                    ],
+                }
+            ]
+        }
+    }
+    settings_dir = os.path.join(worktree_path, ".claude")
+    os.makedirs(settings_dir, exist_ok=True)
+    path = os.path.join(settings_dir, "settings.local.json")
+    with open(path, "w") as f:
+        json.dump(settings, f, indent=2)
+    return os.path.abspath(path)
+
+
 def _write_mcp_config_claude(worktree_path: str, db_path: str) -> str:
-    """Claude Code reads ``.mcp.json`` at the worktree root."""
+    """Claude Code reads ``.mcp.json`` at the worktree root.
+
+    Also drops a PostCompact hook into ``.claude/settings.local.json`` so
+    the task-loop prompt survives compaction (#122). The hook is keyed to
+    claude+implementer because that is the canonical claude worktree
+    role; if the operator routes a different task_type to this pane via
+    `agent_override`, the precedence block in the loop prompt itself
+    handles role disambiguation.
+    """
     interpreter, args, pythonpath = _mcp_python_invocation()
     config = {
         "mcpServers": {
@@ -252,6 +326,9 @@ def _write_mcp_config_claude(worktree_path: str, db_path: str) -> str:
     os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
     with open(path, "w") as f:
         json.dump(config, f, indent=2)
+    _write_postcompact_hook_claude(
+        worktree_path, agent="claude", role="implementer"
+    )
     return os.path.abspath(path)
 
 

--- a/tests/unit/test_postcompact_hook.py
+++ b/tests/unit/test_postcompact_hook.py
@@ -1,0 +1,119 @@
+"""PostCompact hook for Claude worktrees (Issue #122).
+
+After ``/compact`` Claude Code drops the long task-loop system prompt
+that was injected at session start. Without re-injection the agent has
+no rule telling it to call `get_next_task` again, so the pull loop
+stalls until the operator manually re-prompts.
+
+The fix is a per-worktree ``.claude/settings.local.json`` PostCompact
+hook that emits ``additionalContext`` containing the compact restoration
+prompt from ``agent_crew.prompts.task_loop.build_task_loop_prompt_compact``.
+This file pins the contract:
+
+  - the file gets written when claude's MCP config is set up
+  - the hook command uses the same interpreter+PYTHONPATH as the MCP
+    config (so it works in the same env)
+  - executing the hook command produces well-formed JSON that Claude
+    Code can ingest, with ``hookSpecificOutput.additionalContext``
+    containing the compact prompt for the right agent/role
+
+For codex and gemini we don't know an equivalent compact-recovery
+surface yet — explicitly out of scope for this issue. Tracked as a
+follow-up if a new failure mode shows up.
+"""
+import json
+import subprocess
+
+from agent_crew import setup as crew_setup
+
+
+class TestPostCompactHookFileWritten:
+    def test_settings_local_json_created_for_claude(self, tmp_path):
+        wt = tmp_path / "wt"
+        wt.mkdir()
+        crew_setup.write_mcp_config(str(wt), "/db.db", agent="claude")
+        path = wt / ".claude" / "settings.local.json"
+        assert path.exists(), (
+            f"expected PostCompact hook at {path}, but it wasn't created"
+        )
+        config = json.loads(path.read_text())
+        assert "hooks" in config
+        assert "PostCompact" in config["hooks"]
+
+    def test_postcompact_hook_has_command_entry(self, tmp_path):
+        wt = tmp_path / "wt"
+        wt.mkdir()
+        crew_setup.write_mcp_config(str(wt), "/db.db", agent="claude")
+        config = json.loads(
+            (wt / ".claude" / "settings.local.json").read_text()
+        )
+        post = config["hooks"]["PostCompact"]
+        assert isinstance(post, list) and post, "PostCompact must be a non-empty list"
+        # Each block has hooks: [{type: command, command: "...", timeout: N}]
+        inner = post[0]["hooks"]
+        assert any(h.get("type") == "command" and h.get("command") for h in inner)
+
+    def test_codex_does_not_install_postcompact_hook(self, tmp_path):
+        """Codex has no equivalent hook surface — we don't pretend to wire one."""
+        wt = tmp_path / "wt"
+        wt.mkdir()
+        crew_setup.write_mcp_config(str(wt), "/db.db", agent="codex")
+        # The Claude-specific settings file must not be created for a
+        # non-claude worktree — that path belongs to claude only.
+        assert not (wt / ".claude" / "settings.local.json").exists()
+
+    def test_gemini_does_not_install_postcompact_hook(self, tmp_path):
+        wt = tmp_path / "wt"
+        wt.mkdir()
+        crew_setup.write_mcp_config(str(wt), "/db.db", agent="gemini")
+        assert not (wt / ".claude" / "settings.local.json").exists()
+
+
+class TestPostCompactHookExecutes:
+    """Run the hook command end-to-end and parse the JSON it emits."""
+
+    def test_command_prints_well_formed_additional_context(self, tmp_path):
+        wt = tmp_path / "wt"
+        wt.mkdir()
+        crew_setup.write_mcp_config(str(wt), "/db.db", agent="claude")
+        config = json.loads(
+            (wt / ".claude" / "settings.local.json").read_text()
+        )
+        cmd = config["hooks"]["PostCompact"][0]["hooks"][0]["command"]
+
+        # Run the hook the same way Claude Code would: as a shell command.
+        # The command bakes in PYTHONPATH so we don't need to set env here.
+        result = subprocess.run(
+            cmd,
+            shell=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert result.returncode == 0, (
+            f"hook command failed: stderr={result.stderr}"
+        )
+        payload = json.loads(result.stdout)
+        # Claude Code's PostCompact hook contract:
+        out = payload["hookSpecificOutput"]
+        assert out["hookEventName"] == "PostCompact"
+        ctx = out["additionalContext"]
+        # The compact prompt mentions the loop and the right agent.
+        assert "get_next_task" in ctx
+        assert "claude" in ctx
+        assert "submit_result" in ctx
+
+    def test_command_targets_implementer_role_for_claude(self, tmp_path):
+        wt = tmp_path / "wt"
+        wt.mkdir()
+        crew_setup.write_mcp_config(str(wt), "/db.db", agent="claude")
+        config = json.loads(
+            (wt / ".claude" / "settings.local.json").read_text()
+        )
+        cmd = config["hooks"]["PostCompact"][0]["hooks"][0]["command"]
+        result = subprocess.run(
+            cmd, shell=True, capture_output=True, text=True, timeout=10
+        )
+        ctx = json.loads(result.stdout)["hookSpecificOutput"]["additionalContext"]
+        # role mention — full prompt format is "default role: implementer"
+        assert "implementer" in ctx


### PR DESCRIPTION
Closes #122.

## Summary
Adds a per-worktree `.claude/settings.local.json` PostCompact hook that re-injects `build_task_loop_prompt_compact(agent, role)` after Claude Code runs `/compact`. Without this, the long task-loop prompt is dropped and the pull loop stalls until the operator manually re-prompts — the exact failure pattern #122 calls out.

## Behavior
- `write_mcp_config(agent="claude", ...)` now also writes the PostCompact hook into the worktree's `.claude/settings.local.json`.
- Hook command runs the same Python interpreter + PYTHONPATH the MCP config uses, so it survives env changes together with the rest of the wiring.
- Codex and gemini have no equivalent compact surface — the hook is claude-only by design, and tests pin that contract so a future change doesn't silently install a broken hook for the wrong agent.

## Test plan
- [x] 6 new tests in `tests/unit/test_postcompact_hook.py`
  - file gets written for claude
  - file structure correct (`hooks.PostCompact[].hooks[].command`)
  - codex/gemini do NOT install it
  - end-to-end: command runs, emits valid JSON, `additionalContext` contains the compact prompt with the right agent/role
- [x] Full unit + parity suite: 407 passed (was 401 + 6 new)
- [x] ruff clean

## Out of scope
Codex/gemini compact-recovery — separate hook surface (and gemini has its own session model). Filed as a follow-up if those agents start exhibiting the same loss-on-compact pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)