### PR TITLE
feat(#121): stress test harness — 50-run script + log analyzer

### DIFF
--- a/scripts/stress_test_50_runs.sh
+++ b/scripts/stress_test_50_runs.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Stress test: run `crew run` N times against a single project, then check
+# the server log for watchdog timeouts. Acceptance criterion for #121
+# (parent #106): N consecutive runs must produce zero `WATCHDOG TIMEOUT`
+# events. Today's tmux-push baseline produces 1-2 per ~10 runs (#102,
+# #105 sample); after the MCP-pull cutover (#119) this number must hit 0.
+#
+# Usage:
+#   scripts/stress_test_50_runs.sh [-n N] [-p PROJECT] [-t "TASK"]
+#       [--base ~/.agent_crew]
+#
+# Flags:
+#   -n N        number of runs (default: 50)
+#   -p PROJECT  project name (default: agent_crew)
+#   -t TASK     task body sent to `crew run` (default: trivial echo task)
+#   --base DIR  state base directory (default: ~/.agent_crew)
+#   -h          help
+#
+# After the run, the script invokes the analyzer:
+#
+#   python -m agent_crew._stress_log_analyzer <state>/<project>/server.log
+#
+# and exits 0 only when the analyzer reports PASS (zero timeouts).
+
+set -euo pipefail
+
+N=50
+PROJECT="agent_crew"
+TASK="No-op stress probe — return immediately with status=completed"
+BASE="${HOME}/.agent_crew"
+
+usage() {
+  sed -n '2,28p' "$0"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -n) N="$2"; shift 2 ;;
+    -p) PROJECT="$2"; shift 2 ;;
+    -t) TASK="$2"; shift 2 ;;
+    --base) BASE="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown arg: $1" >&2; usage; exit 64 ;;
+  esac
+done
+
+STATE_DIR="${BASE}/${PROJECT}"
+LOG_PATH="${STATE_DIR}/server.log"
+RUN_LOG="$(mktemp -t crew-stress.XXXXXX.log)"
+
+if [[ ! -d "$STATE_DIR" ]]; then
+  echo "no project state at ${STATE_DIR} — run 'crew setup ${PROJECT}' first" >&2
+  exit 2
+fi
+
+echo "stress: ${N} runs of project=${PROJECT}"
+echo "stress: server log: ${LOG_PATH}"
+echo "stress: per-run output: ${RUN_LOG}"
+
+# Mark the log start so the analyzer can scope to this stress session
+# instead of the project's full history. We append a synthetic marker
+# the analyzer ignores.
+START_MARKER="STRESS-START-$(date -Iseconds)-$$"
+echo "[stress] ${START_MARKER}" >>"$LOG_PATH" || true
+
+failed_runs=0
+for i in $(seq 1 "$N"); do
+  echo "── run ${i}/${N} ──" | tee -a "$RUN_LOG"
+  if ! crew run "${TASK} (#${i})" --project "$PROJECT" --base "$BASE" >>"$RUN_LOG" 2>&1; then
+    failed_runs=$((failed_runs + 1))
+    echo "stress: run ${i} failed (rc != 0)" | tee -a "$RUN_LOG"
+  fi
+done
+
+echo
+echo "stress: ${N} runs complete. ${failed_runs} non-zero exit(s) on the wrapper."
+echo
+
+# Slice the log to the stress window via the start marker, then analyze.
+SLICED="$(mktemp -t crew-stress-slice.XXXXXX.log)"
+awk -v m="${START_MARKER}" 'found {print} index($0, m){found=1}' "$LOG_PATH" >"$SLICED"
+
+echo "stress: analyzer report ─────────────────────────────────"
+python3 -m agent_crew._stress_log_analyzer "$SLICED" || RC=$?
+RC="${RC:-0}"
+echo "─────────────────────────────────────────────────────────"
+echo "wrapper failed_runs: ${failed_runs}"
+echo "analyzer rc: ${RC}"
+
+# We exit non-zero if EITHER any wrapper exited non-zero OR the analyzer
+# found a watchdog timeout in the log slice.
+if [[ "$failed_runs" -ne 0 || "$RC" -ne 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/src/agent_crew/_stress_log_analyzer.py
+++ b/src/agent_crew/_stress_log_analyzer.py
@@ -1,0 +1,121 @@
+"""Stress-run log analyzer (Issue #121 acceptance support).
+
+`scripts/stress_test_50_runs.sh` runs ``crew run`` N times and points
+at the server's log + the wrapper-side stdout. After the run, the
+operator (or this analyzer programmatically) needs to know how many of
+the failure modes #121 cares about actually fired:
+
+  - server-side: ``WATCHDOG TIMEOUT: ...`` / ``watchdog timeout: pane idle``
+  - CLI-side:    ``watchdog timeout: CLI detected pane idle ...``
+                 ``watchdog timeout: crew run wrapper exited ...``
+
+These are emitted as plain log lines by ``server.py`` and ``cli.py``
+respectively. We grep them rather than re-parse structured logs because
+the format has been stable for three issue cycles (#85, #87, #92, #103)
+and a regex change was always preferred over a schema change.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Iterable
+
+# Order matters — first match wins so a single line with multiple
+# patterns gets categorized once. The two CLI-side patterns are more
+# specific than the generic "watchdog timeout: pane idle" / "WATCHDOG
+# TIMEOUT" markers, so they must match first.
+_PATTERNS: tuple[tuple[str, re.Pattern], ...] = (
+    (
+        "cli_wrapper_exit",
+        re.compile(r"watchdog timeout:\s+crew run wrapper exited", re.IGNORECASE),
+    ),
+    (
+        "cli_pane_idle",
+        re.compile(r"watchdog timeout:\s+CLI detected pane idle", re.IGNORECASE),
+    ),
+    (
+        "server_pane_idle",
+        re.compile(r"watchdog timeout:\s+pane idle", re.IGNORECASE),
+    ),
+    # Bare "WATCHDOG TIMEOUT:" header (server.py:499). The other server
+    # marker also gets emitted alongside this one, so we keep this last
+    # to catch lines that don't carry the more specific suffix.
+    ("server_watchdog_timeout", re.compile(r"WATCHDOG TIMEOUT:", re.IGNORECASE)),
+)
+
+
+@dataclass
+class StressLogReport:
+    total_lines: int
+    counts: dict[str, int]
+    matching_lines: list[tuple[str, str]]  # (category, line)
+
+    @property
+    def total_timeouts(self) -> int:
+        return sum(self.counts.values())
+
+    @property
+    def passed(self) -> bool:
+        """#121 acceptance criterion: zero watchdog timeouts."""
+        return self.total_timeouts == 0
+
+
+def analyze(lines: Iterable[str]) -> StressLogReport:
+    """Scan log lines and bucket each match into a category."""
+    counts: dict[str, int] = {name: 0 for name, _ in _PATTERNS}
+    matching: list[tuple[str, str]] = []
+    total = 0
+    for raw in lines:
+        total += 1
+        line = raw.rstrip("\n")
+        for name, pat in _PATTERNS:
+            if pat.search(line):
+                counts[name] += 1
+                matching.append((name, line))
+                break
+    return StressLogReport(
+        total_lines=total,
+        counts=counts,
+        matching_lines=matching,
+    )
+
+
+def analyze_path(path: str) -> StressLogReport:
+    with open(path, encoding="utf-8", errors="replace") as f:
+        return analyze(f)
+
+
+def format_report(report: StressLogReport, *, max_examples: int = 3) -> str:
+    """Human-readable summary suitable for CI logs / Telegram messages."""
+    lines = []
+    verdict = "PASS" if report.passed else "FAIL"
+    lines.append(
+        f"stress log analysis: {verdict} "
+        f"({report.total_timeouts} timeout(s) across {report.total_lines} lines)"
+    )
+    for name, count in report.counts.items():
+        lines.append(f"  {name}: {count}")
+    if report.matching_lines:
+        lines.append("examples:")
+        for category, line in report.matching_lines[:max_examples]:
+            lines.append(f"  [{category}] {line[:200]}")
+    return "\n".join(lines)
+
+
+def main() -> int:  # pragma: no cover — CLI shim
+    import argparse
+
+    p = argparse.ArgumentParser(
+        description="Analyze a server.log for #121 watchdog-timeout markers."
+    )
+    p.add_argument("log_path")
+    p.add_argument("--max-examples", type=int, default=5)
+    args = p.parse_args()
+
+    report = analyze_path(args.log_path)
+    print(format_report(report, max_examples=args.max_examples))
+    return 0 if report.passed else 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/unit/test_stress_log_analyzer.py
+++ b/tests/unit/test_stress_log_analyzer.py
@@ -1,0 +1,154 @@
+"""Tests for the #121 stress log analyzer.
+
+The analyzer reads a server.log slice and reports whether any watchdog
+timeout markers fired during the stress window. The bash harness in
+`scripts/stress_test_50_runs.sh` shells out to it; these tests pin the
+parsing rules so a future log-format tweak surfaces here, not in
+production after a 50-run sample wasted on a regex drift.
+"""
+from agent_crew._stress_log_analyzer import (
+    StressLogReport,
+    analyze,
+    analyze_path,
+    format_report,
+)
+
+
+# ---------------------------------------------------------------------------
+# analyze() — pattern matching
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzeMatches:
+    def test_clean_log_passes_with_zero_timeouts(self):
+        log = [
+            "[2026-04-28 03:00:00] INFO: POST /tasks: enqueued task_id=t1",
+            "[2026-04-28 03:00:01] INFO: PUSH SUCCESS: task_id=t1",
+            "[2026-04-28 03:00:02] INFO: POST /tasks/t1/result: status=completed",
+        ]
+        report = analyze(log)
+        assert report.passed is True
+        assert report.total_timeouts == 0
+
+    def test_server_watchdog_timeout_caught(self):
+        log = [
+            "[2026-04-28 03:00:00] INFO: ok",
+            "[2026-04-28 03:00:01] WARNING: WATCHDOG TIMEOUT: task_id=t-bad marked failed",
+        ]
+        report = analyze(log)
+        assert report.passed is False
+        assert report.counts["server_watchdog_timeout"] == 1
+
+    def test_server_pane_idle_caught(self):
+        log = [
+            "watchdog timeout: pane idle 600s without progress on t-stuck",
+        ]
+        report = analyze(log)
+        assert report.counts["server_pane_idle"] == 1
+
+    def test_cli_pane_idle_caught(self):
+        log = [
+            "Warning: watchdog timeout: CLI detected pane idle for 320s on task 't1'",
+        ]
+        report = analyze(log)
+        assert report.counts["cli_pane_idle"] == 1
+
+    def test_cli_wrapper_exit_caught(self):
+        log = [
+            "Warning: watchdog timeout: crew run wrapper exited after 600s",
+        ]
+        report = analyze(log)
+        assert report.counts["cli_wrapper_exit"] == 1
+
+    def test_each_line_counted_once(self):
+        # A line that matches more than one pattern (e.g. the literal
+        # "WATCHDOG TIMEOUT" alongside "watchdog timeout: pane idle")
+        # only contributes to the first matching bucket — keeps the
+        # totals from double-counting.
+        log = [
+            "WARNING: WATCHDOG TIMEOUT: task_id=t-x; watchdog timeout: pane idle 600s",
+        ]
+        report = analyze(log)
+        assert report.total_timeouts == 1
+
+    def test_case_insensitive(self):
+        log = ["WaTcHdOg TiMeOuT: pAnE iDlE for ages"]
+        report = analyze(log)
+        assert report.counts["server_pane_idle"] == 1
+
+    def test_total_lines_includes_non_matches(self):
+        log = ["normal", "more normal", "WATCHDOG TIMEOUT: bad"]
+        report = analyze(log)
+        assert report.total_lines == 3
+        assert report.total_timeouts == 1
+
+
+# ---------------------------------------------------------------------------
+# analyze_path / format_report — round trip
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzePath:
+    def test_reads_file_and_returns_report(self, tmp_path):
+        log_path = tmp_path / "server.log"
+        log_path.write_text(
+            "INFO: enqueue ok\n"
+            "WARNING: WATCHDOG TIMEOUT: task t-1 marked failed\n"
+            "INFO: completed t-2\n"
+        )
+        report = analyze_path(str(log_path))
+        assert report.passed is False
+        assert report.total_timeouts == 1
+
+
+class TestFormatReport:
+    def test_pass_report_says_pass(self):
+        report = StressLogReport(
+            total_lines=42,
+            counts={
+                "server_watchdog_timeout": 0,
+                "server_pane_idle": 0,
+                "cli_pane_idle": 0,
+                "cli_wrapper_exit": 0,
+            },
+            matching_lines=[],
+        )
+        out = format_report(report)
+        assert "PASS" in out
+        assert "0 timeout(s)" in out
+
+    def test_fail_report_lists_examples(self):
+        report = StressLogReport(
+            total_lines=10,
+            counts={
+                "server_watchdog_timeout": 1,
+                "server_pane_idle": 0,
+                "cli_pane_idle": 0,
+                "cli_wrapper_exit": 0,
+            },
+            matching_lines=[
+                ("server_watchdog_timeout", "WATCHDOG TIMEOUT: task t-x"),
+            ],
+        )
+        out = format_report(report)
+        assert "FAIL" in out
+        assert "1 timeout(s)" in out
+        assert "task t-x" in out
+
+    def test_examples_truncated_to_max(self):
+        matching = [
+            ("server_watchdog_timeout", f"WATCHDOG TIMEOUT: task t-{i}")
+            for i in range(10)
+        ]
+        report = StressLogReport(
+            total_lines=10,
+            counts={
+                "server_watchdog_timeout": 10,
+                "server_pane_idle": 0,
+                "cli_pane_idle": 0,
+                "cli_wrapper_exit": 0,
+            },
+            matching_lines=matching,
+        )
+        out = format_report(report, max_examples=2)
+        assert out.count("WATCHDOG TIMEOUT") == 2


### PR DESCRIPTION
Partial close on #121. Ships the harness; the actual 50-run validation pass is an operator action.

## Summary
- `scripts/stress_test_50_runs.sh` — bash driver. Marks the server log with a session sentinel, runs `crew run` N times (default 50), slices the log to that window, pipes it into the analyzer, exits non-zero on any wrapper failure or any analyzer-detected timeout.
- `src/agent_crew/_stress_log_analyzer.py` — pure Python parser. Buckets timeout markers into 4 categories (cli wrapper exit, cli pane idle, server pane idle, server WATCHDOG TIMEOUT header) so a regression report points at the failing layer.
- `tests/unit/test_stress_log_analyzer.py` — 12 new tests pinning the regex contracts so a future log-format tweak surfaces here, not in production after a wasted 50-run sample.

## Why "partial close"
Running the actual 50-run pass spends real LLM tokens (claude/codex/gemini × 50 trivial tasks) and needs a healthy `crew setup` session attached. That's deferred to the operator. When the smoke results land, the issue can close fully — the harness alone doesn't satisfy "0 watchdog timeouts in 50 runs".

## Test plan
- [x] Unit suite: 419 passed (was 407 + 12 new), 0 regressions.
- [x] `bash scripts/stress_test_50_runs.sh -h` prints help block.
- [x] `python -m agent_crew._stress_log_analyzer` exits 0 on a clean log fixture and 1 on a fixture containing each of the 4 timeout markers.
- [ ] Actual 50-run pass against `crew setup agent_crew` — operator decision.

## Operator runbook
```sh
crew setup agent_crew                # if not already up
scripts/stress_test_50_runs.sh -p agent_crew
echo $?                              # must be 0
```
The script's analyzer summary at the tail of stdout is the artifact to attach to the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)