### PR TITLE
feat(#119 phase 6a): AGENT_CREW_DELIVERY env flag for safe cutover

### DIFF
--- a/src/agent_crew/server.py
+++ b/src/agent_crew/server.py
@@ -330,6 +330,21 @@ def create_app(
             "1", "true", "yes",
         )
 
+    # Phase 6a of the tmux→MCP cutover (Issue #119). The flag selects
+    # whether the server actively pushes new tasks via tmux paste-buffer
+    # (legacy ``push``), relies entirely on the agent's MCP pull loop
+    # (``mcp``), or runs both paths concurrently (``both`` — default;
+    # safe because MCP get_next_task is atomic and a task already
+    # delivered via push transitions to in_progress before MCP could
+    # return it).
+    #
+    # Anything unrecognized falls back to ``both`` so a config typo
+    # never silently disables delivery.
+    _delivery_raw = os.getenv("AGENT_CREW_DELIVERY", "both").strip().lower()
+    if _delivery_raw not in ("push", "mcp", "both"):
+        _delivery_raw = "both"
+    _push_enabled = _delivery_raw in ("push", "both")
+
     state: dict = {}
     reminded_task_ids: set[str] = set()
 
@@ -362,6 +377,9 @@ def create_app(
     def _try_push_next(role: str) -> None:
         """If the role has an available pane and is idle, dequeue and push the next task."""
         logger.debug(f"_try_push_next: role={role}")
+        if not _push_enabled:
+            logger.debug(f"_try_push_next: push disabled (AGENT_CREW_DELIVERY={_delivery_raw})")
+            return
         if not pane_map:
             logger.debug(f"_try_push_next: no pane_map")
             return
@@ -412,6 +430,9 @@ def create_app(
         the role keys. Busy-check and dequeue are both scoped to the agent so
         concurrent panelists don't block each other."""
         logger.debug(f"_try_push_discuss: agent={agent}")
+        if not _push_enabled:
+            logger.debug(f"_try_push_discuss: push disabled (AGENT_CREW_DELIVERY={_delivery_raw})")
+            return
         if not pane_map or not agent:
             logger.debug(f"_try_push_discuss: no pane_map or agent")
             return

--- a/tests/unit/test_delivery_flag.py
+++ b/tests/unit/test_delivery_flag.py
@@ -1,0 +1,136 @@
+"""AGENT_CREW_DELIVERY env-flag gating (Issue #119 phase 6a).
+
+Phase 6a of the cutover: introduce a single knob that lets the operator
+turn off the tmux push path without removing the code. With ``mcp`` set,
+the server stops pushing and agents must rely on the MCP pull loop —
+which gives us a way to validate the cutover in production before phase
+6b/6c remove the push code entirely.
+
+Accepted values:
+    "push"  → push enabled (legacy behavior)
+    "mcp"   → push disabled
+    "both"  → push enabled (default; alias for push since MCP pull is
+              always available alongside)
+    anything else → fall back to default (push enabled)
+
+Tested at the HTTP boundary because that's the surface the operator
+actually flips: a fresh ``crew setup`` reads the env when the server
+spawns, so a pure unit test against ``create_app`` mirrors production.
+"""
+from fastapi.testclient import TestClient
+
+from agent_crew.server import create_app
+
+
+def _task_payload(task_id="t1", task_type="implement"):
+    return {
+        "task_id": task_id,
+        "task_type": task_type,
+        "description": "do work",
+        "branch": "main",
+        "priority": 3,
+        "context": {},
+        "project": "",
+    }
+
+
+class _RecordingPush:
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, pane_id, text):
+        self.calls.append((pane_id, text))
+
+
+PANE_MAP = {"implementer": "%100", "claude": "%100"}
+
+
+class TestDefaultIsBoth:
+    def test_no_env_pushes_normally(self, tmp_db, monkeypatch):
+        monkeypatch.delenv("AGENT_CREW_DELIVERY", raising=False)
+        push = _RecordingPush()
+        app = create_app(
+            db_path=tmp_db, pane_map=PANE_MAP, port=8100, push_fn=push,
+        )
+        with TestClient(app) as client:
+            client.post("/tasks", json=_task_payload("t1"))
+        assert len(push.calls) == 1
+
+
+class TestExplicitValues:
+    def test_both_pushes(self, tmp_db, monkeypatch):
+        monkeypatch.setenv("AGENT_CREW_DELIVERY", "both")
+        push = _RecordingPush()
+        app = create_app(
+            db_path=tmp_db, pane_map=PANE_MAP, port=8100, push_fn=push,
+        )
+        with TestClient(app) as client:
+            client.post("/tasks", json=_task_payload("t-both"))
+        assert len(push.calls) == 1
+
+    def test_push_pushes(self, tmp_db, monkeypatch):
+        monkeypatch.setenv("AGENT_CREW_DELIVERY", "push")
+        push = _RecordingPush()
+        app = create_app(
+            db_path=tmp_db, pane_map=PANE_MAP, port=8100, push_fn=push,
+        )
+        with TestClient(app) as client:
+            client.post("/tasks", json=_task_payload("t-push"))
+        assert len(push.calls) == 1
+
+    def test_mcp_does_not_push(self, tmp_db, monkeypatch):
+        monkeypatch.setenv("AGENT_CREW_DELIVERY", "mcp")
+        push = _RecordingPush()
+        app = create_app(
+            db_path=tmp_db, pane_map=PANE_MAP, port=8100, push_fn=push,
+        )
+        with TestClient(app) as client:
+            # Task is enqueued but no push fires.
+            resp = client.post("/tasks", json=_task_payload("t-mcp"))
+            assert resp.status_code == 201
+        assert push.calls == []
+
+    def test_unrecognized_value_falls_back_to_default(self, tmp_db, monkeypatch):
+        monkeypatch.setenv("AGENT_CREW_DELIVERY", "bogus")
+        push = _RecordingPush()
+        app = create_app(
+            db_path=tmp_db, pane_map=PANE_MAP, port=8100, push_fn=push,
+        )
+        with TestClient(app) as client:
+            client.post("/tasks", json=_task_payload("t-bogus"))
+        # An invalid value must not silently disable push — that would
+        # be a config-typo footgun. Default = push enabled.
+        assert len(push.calls) == 1
+
+
+class TestMcpStillCascadesAfterSubmit:
+    """With push off, the auto-enqueue cascade still runs (#123). The
+    review task lands in the queue, just without a push notification —
+    the agent's MCP loop will pick it up on the next get_next_task."""
+
+    def test_impl_completed_creates_review_in_queue_without_push(
+        self, tmp_db, monkeypatch
+    ):
+        monkeypatch.setenv("AGENT_CREW_DELIVERY", "mcp")
+        push = _RecordingPush()
+        app = create_app(
+            db_path=tmp_db, pane_map=PANE_MAP, port=8100, push_fn=push,
+        )
+        with TestClient(app) as client:
+            client.post("/tasks", json=_task_payload("imp-1"))
+            client.post(
+                "/tasks/imp-1/result",
+                json={
+                    "task_id": "imp-1",
+                    "status": "completed",
+                    "summary": "done",
+                    "verdict": None,
+                    "findings": [],
+                    "pr_number": None,
+                },
+            )
+            tasks = client.get("/tasks").json()
+        # Review task got created.
+        assert any(t["task_type"] == "review" for t in tasks)
+        # No push fired anywhere along the way.
+        assert push.calls == []


### PR DESCRIPTION
Phase 6a of #119 cutover. Adds an env-gated knob that turns off the tmux push path without removing the code, so the cutover can be observed in production with a fast-revert safety net.

## Flag values
| Value  | Behavior |
|--------|----------|
| `push` | push enabled (legacy) |
| `mcp`  | push disabled — agent uses MCP pull only |
| `both` | push enabled + MCP available (**default**) |
| other  | falls back to `both` — config-typo safe |

Both `_try_push_next` and `_try_push_discuss` honor the gate. The auto-enqueue cascade (#123) is unaffected: review/test tasks still get created on result submission, and an MCP-pull agent picks them up on its next `get_next_task`.

## Cutover plan
- **Phase 6a (this PR):** flag introduced, default `both` — zero behavior change for existing operators.
- **Phase 6b (separate PR after observation):** flip default to `mcp` — push remains available via explicit `AGENT_CREW_DELIVERY=push`.
- **Phase 6c (separate PR):** remove `_default_push`, `_pane_has_task`, paste-buffer/send-keys. Closes #119.

## Test plan
- [x] 6 new tests in `tests/unit/test_delivery_flag.py`: default → push fires; explicit `both`/`push` → push fires; `mcp` → no push; invalid value → push (fail-safe); cascade-without-push end-to-end check
- [x] Full suite: 425 passed (was 419 + 6 new), 0 regressions

## Acceptance gates already cleared
- #120 HTTP↔MCP parity ✓
- #122 PostCompact hook for claude task-loop ✓
- #123 transport-agnostic stage cascade ✓
- #121 stress harness ✓ (50-run pass deferred to operator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)