### PR TITLE
fix: agent reliability — token auto-clear, Gemini prompt dismissal, stale pending re-dispatch

### DIFF
--- a/src/agent_crew/queue.py
+++ b/src/agent_crew/queue.py
@@ -669,6 +669,32 @@ class TaskQueue:
         finally:
             conn.close()
 
+    def list_stale_pending(self, older_than_seconds: float, now: float) -> List[dict]:
+        """Return pending tasks whose created_at is more than older_than_seconds ago.
+
+        Used by the watchdog (#136) to re-dispatch tasks that were enqueued but
+        never picked up (e.g. pane was busy or push was missed).
+        """
+        cutoff = now - older_than_seconds
+        conn = self._connect()
+        try:
+            rows = conn.execute(
+                "SELECT task_id, task_type, context, created_at FROM tasks "
+                "WHERE status = 'pending' AND created_at < ?",
+                (cutoff,),
+            ).fetchall()
+            return [
+                {
+                    "task_id": r["task_id"],
+                    "task_type": r["task_type"],
+                    "context": json.loads(r["context"]) if r["context"] else {},
+                    "created_at": r["created_at"],
+                }
+                for r in rows
+            ]
+        finally:
+            conn.close()
+
     def list_checkpoints(self, task_id: str) -> List[dict]:
         """List all checkpoints for a task."""
         conn = self._connect()

--- a/src/agent_crew/server.py
+++ b/src/agent_crew/server.py
@@ -3,6 +3,7 @@ import contextlib
 import json
 import logging
 import os
+import re
 import subprocess
 import sys
 import time
@@ -96,6 +97,65 @@ def _pane_is_busy(pane_id: str) -> bool:
     prev = _PANE_BUSY_LAST.get(pane_id)
     _PANE_BUSY_LAST[pane_id] = current
     return prev is not None and current != prev
+
+
+_TOKEN_CLEAR_THRESHOLD = int(os.getenv("AGENT_CREW_TOKEN_CLEAR_THRESHOLD", "200000"))
+_TOKEN_COUNT_RE = re.compile(r"save\s+([\d,]+(?:\.\d+)?[kKmM]?)\s+tokens", re.IGNORECASE)
+
+
+def _pane_token_count(pane_id: str) -> int:
+    """Return the token count hinted in the pane status bar, or 0.
+
+    Claude Code shows "new task? /clear to save 544.1k tokens" when context
+    is large. We parse that hint to detect saturation (#133).
+    """
+    try:
+        r = subprocess.run(
+            ["tmux", "capture-pane", "-p", "-t", pane_id],
+            capture_output=True, text=True,
+        )
+    except Exception:
+        return 0
+    m = _TOKEN_COUNT_RE.search(r.stdout)
+    if not m:
+        return 0
+    raw = m.group(1).replace(",", "")
+    if raw.lower().endswith("k"):
+        return int(float(raw[:-1]) * 1_000)
+    if raw.lower().endswith("m"):
+        return int(float(raw[:-1]) * 1_000_000)
+    return int(float(raw))
+
+
+def _pane_clear_context(pane_id: str) -> None:
+    """Send /clear to a Claude pane to reset context (#133)."""
+    subprocess.run(["tmux", "send-keys", "-t", pane_id, "/clear", "Enter"],
+                   capture_output=True)
+    import time as _time
+    _time.sleep(2.0)
+
+
+_GEMINI_PERMISSION_RE = re.compile(r"Allow execution of .+\?", re.IGNORECASE)
+
+
+def _pane_dismiss_permission_prompt(pane_id: str) -> bool:
+    """If a gemini permission prompt is visible, auto-select 'Allow for this session'.
+
+    Returns True if a prompt was found and dismissed (#134).
+    """
+    try:
+        r = subprocess.run(
+            ["tmux", "capture-pane", "-p", "-t", pane_id],
+            capture_output=True, text=True,
+        )
+    except Exception:
+        return False
+    if not _GEMINI_PERMISSION_RE.search(r.stdout):
+        return False
+    subprocess.run(["tmux", "send-keys", "-t", pane_id, "2", "Enter"],
+                   capture_output=True)
+    logger.info(f"_pane_dismiss_permission_prompt: dismissed gemini prompt on {pane_id}")
+    return True
 
 
 def _pane_has_task(pane_id: str) -> bool:
@@ -422,6 +482,16 @@ def create_app(
             return
 
         logger.info(f"_try_push_next: dequeued task_id={task.task_id}, calling push_fn")
+        # #133: clear oversized context before pushing so claude doesn't stall.
+        tok = _pane_token_count(pane_id)
+        if tok >= _TOKEN_CLEAR_THRESHOLD:
+            logger.info(
+                f"_try_push_next: pane {pane_id} has {tok} tokens "
+                f"(>= {_TOKEN_CLEAR_THRESHOLD}) — sending /clear before push"
+            )
+            _pane_clear_context(pane_id)
+        # #134: auto-dismiss gemini permission prompt if present.
+        _pane_dismiss_permission_prompt(pane_id)
         push_fn(pane_id, _format_task_message(task, port))
 
     def _try_push_discuss(agent: Optional[str]) -> None:
@@ -499,6 +569,9 @@ def create_app(
             if not pane_id:
                 continue
             try:
+                # #134: dismiss gemini permission prompt before busy-check so
+                # the prompt doesn't freeze the pane and appear as idle.
+                _pane_dismiss_permission_prompt(pane_id)
                 if pane_busy_fn(pane_id):
                     q().bump_activity(task_id, ts=now)
                     actions["bumped"].append(task_id)
@@ -568,6 +641,45 @@ def create_app(
                         f"WATCHDOG REMINDER: task_id={task_id} idle for "
                         f"{idle_for:.0f}s — nudged pane {pane_id}"
                     )
+        # #136: re-dispatch stale pending tasks that were never picked up.
+        # A task stays "pending" when the target pane was busy at enqueue time
+        # and no subsequent push fired. We nudge _try_push_next so the role's
+        # pane gets another delivery attempt.
+        stale_pending_seconds = float(
+            os.getenv("AGENT_CREW_STALE_PENDING_SECONDS", "120")
+        )
+        try:
+            stale = q().list_stale_pending(stale_pending_seconds, now)
+        except Exception:
+            logger.exception("watchdog: list_stale_pending raised — skipping")
+            stale = []
+        # Collect unique roles so we only fire _try_push_next once per role.
+        stale_roles: set[str] = set()
+        for sp in stale:
+            task_type = sp.get("task_type", "")
+            ctx = sp.get("context") or {}
+            if task_type == "discuss":
+                agent = ctx.get("agent") if isinstance(ctx, dict) else None
+                if agent and agent in (pane_map or {}):
+                    stale_roles.add(f"discuss:{agent}")
+            else:
+                role = _TYPE_TO_ROLE.get(task_type)
+                if role:
+                    stale_roles.add(role)
+        for role_key in stale_roles:
+            try:
+                if role_key.startswith("discuss:"):
+                    _try_push_discuss(role_key.split(":", 1)[1])
+                else:
+                    _try_push_next(role_key)
+                logger.info(f"watchdog: re-dispatched stale pending for role={role_key}")
+            except Exception:
+                logger.exception(
+                    f"watchdog: re-dispatch failed for role={role_key}"
+                )
+        if stale_roles:
+            actions["stale_redispatched"] = list(stale_roles)
+
         return actions
 
     # Stash the tick for tests; harmless in production (never read by handlers).

--- a/tests/unit/test_pane_helpers.py
+++ b/tests/unit/test_pane_helpers.py
@@ -1,0 +1,216 @@
+"""Unit tests for server.py pane helper functions (#133, #134, #136).
+
+- _pane_token_count: parses Claude Code token hint from pane content
+- _pane_clear_context: sends /clear when token threshold exceeded
+- _pane_dismiss_permission_prompt: auto-dismisses gemini permission prompts
+- list_stale_pending: queue method for #136 re-dispatch logic
+"""
+import time
+from unittest.mock import MagicMock, call, patch
+
+from agent_crew.server import (
+    _GEMINI_PERMISSION_RE,
+    _TOKEN_COUNT_RE,
+    _pane_clear_context,
+    _pane_dismiss_permission_prompt,
+    _pane_token_count,
+)
+
+
+# ---------------------------------------------------------------------------
+# _pane_token_count  (#133)
+# ---------------------------------------------------------------------------
+
+
+def _fake_capture(stdout: str):
+    m = MagicMock()
+    m.stdout = stdout
+    return m
+
+
+def test_pane_token_count_k_suffix():
+    """'save 544.1k tokens' → 544100"""
+    with patch("agent_crew.server.subprocess.run", return_value=_fake_capture(
+        "new task? /clear to save 544.1k tokens"
+    )):
+        assert _pane_token_count("%1") == 544_100
+
+
+def test_pane_token_count_m_suffix():
+    """'save 1.2M tokens' → 1200000"""
+    with patch("agent_crew.server.subprocess.run", return_value=_fake_capture(
+        "new task? /clear to save 1.2M tokens"
+    )):
+        assert _pane_token_count("%1") == 1_200_000
+
+
+def test_pane_token_count_plain_integer():
+    """'save 200000 tokens' → 200000"""
+    with patch("agent_crew.server.subprocess.run", return_value=_fake_capture(
+        "/clear to save 200,000 tokens"
+    )):
+        assert _pane_token_count("%1") == 200_000
+
+
+def test_pane_token_count_no_hint():
+    """No token hint → 0"""
+    with patch("agent_crew.server.subprocess.run", return_value=_fake_capture(
+        "claude is thinking..."
+    )):
+        assert _pane_token_count("%1") == 0
+
+
+def test_pane_token_count_subprocess_failure():
+    """subprocess.run raises → returns 0 without crashing"""
+    with patch("agent_crew.server.subprocess.run", side_effect=OSError("no tmux")):
+        assert _pane_token_count("%1") == 0
+
+
+# ---------------------------------------------------------------------------
+# _pane_clear_context  (#133)
+# ---------------------------------------------------------------------------
+
+
+def test_pane_clear_context_sends_slash_clear():
+    """/clear is sent to the correct pane."""
+    calls = []
+    def fake_run(cmd, **_kw):
+        calls.append(cmd)
+        return MagicMock()
+
+    with patch("agent_crew.server.subprocess.run", side_effect=fake_run):
+        with patch("agent_crew.server.time.sleep"):
+            _pane_clear_context("%5")
+
+    assert any("/clear" in " ".join(c) for c in calls)
+    assert any("%5" in " ".join(c) for c in calls)
+
+
+# ---------------------------------------------------------------------------
+# _pane_dismiss_permission_prompt  (#134)
+# ---------------------------------------------------------------------------
+
+
+_GEMINI_PROMPT = (
+    "Allow execution of tools requested by this agent?\n"
+    "  1) No\n  2) Yes, allow for this session\n"
+)
+
+
+def test_pane_dismiss_returns_true_when_prompt_present():
+    """Returns True and sends '2' when gemini permission prompt is visible."""
+    sent = []
+
+    def fake_run(cmd, **_kw):
+        if "capture-pane" in cmd:
+            m = MagicMock()
+            m.stdout = _GEMINI_PROMPT
+            return m
+        sent.append(cmd)
+        return MagicMock()
+
+    with patch("agent_crew.server.subprocess.run", side_effect=fake_run):
+        result = _pane_dismiss_permission_prompt("%7")
+
+    assert result is True
+    assert any("2" in c for c in sent)
+
+
+def test_pane_dismiss_returns_false_when_no_prompt():
+    """Returns False and does NOT send keys when no permission prompt."""
+    sent = []
+
+    def fake_run(cmd, **_kw):
+        if "capture-pane" in cmd:
+            m = MagicMock()
+            m.stdout = "claude is processing..."
+            return m
+        sent.append(cmd)
+        return MagicMock()
+
+    with patch("agent_crew.server.subprocess.run", side_effect=fake_run):
+        result = _pane_dismiss_permission_prompt("%7")
+
+    assert result is False
+    # send-keys must NOT have been called
+    assert not any("send-keys" in " ".join(c) for c in sent)
+
+
+def test_pane_dismiss_subprocess_failure_returns_false():
+    with patch("agent_crew.server.subprocess.run", side_effect=OSError("no tmux")):
+        assert _pane_dismiss_permission_prompt("%3") is False
+
+
+# ---------------------------------------------------------------------------
+# list_stale_pending  (#136)  — queue method test
+# ---------------------------------------------------------------------------
+
+
+def test_list_stale_pending_returns_old_tasks(tmp_db):
+    """Pending tasks older than the threshold are returned."""
+    from agent_crew.queue import TaskQueue
+
+    q = TaskQueue(tmp_db)
+    old_ts = time.time() - 200  # 200s ago
+    from agent_crew.protocol import TaskRequest
+
+    req = TaskRequest(
+        task_id="stale-1",
+        task_type="implement",
+        description="old work",
+        branch="main",
+    )
+    # Enqueue normally then update created_at to be old.
+    q.enqueue(req)
+    conn = q._connect()
+    conn.execute("UPDATE tasks SET created_at = ? WHERE task_id = ?", (old_ts, "stale-1"))
+    conn.commit()
+    conn.close()
+
+    stale = q.list_stale_pending(older_than_seconds=120, now=time.time())
+    assert any(r["task_id"] == "stale-1" for r in stale)
+
+
+def test_list_stale_pending_excludes_fresh_tasks(tmp_db):
+    """Tasks enqueued recently are NOT returned as stale."""
+    from agent_crew.queue import TaskQueue
+    from agent_crew.protocol import TaskRequest
+
+    q = TaskQueue(tmp_db)
+    req = TaskRequest(
+        task_id="fresh-1",
+        task_type="implement",
+        description="new work",
+        branch="main",
+    )
+    q.enqueue(req)
+
+    stale = q.list_stale_pending(older_than_seconds=120, now=time.time())
+    assert not any(r["task_id"] == "fresh-1" for r in stale)
+
+
+def test_list_stale_pending_excludes_in_progress(tmp_db):
+    """in_progress tasks are never returned (only pending)."""
+    from agent_crew.queue import TaskQueue
+    from agent_crew.protocol import TaskRequest
+
+    q = TaskQueue(tmp_db)
+    old_ts = time.time() - 500
+
+    req = TaskRequest(
+        task_id="prog-1",
+        task_type="implement",
+        description="in progress work",
+        branch="main",
+    )
+    q.enqueue(req)
+    conn = q._connect()
+    conn.execute(
+        "UPDATE tasks SET status = 'in_progress', created_at = ? WHERE task_id = ?",
+        (old_ts, "prog-1"),
+    )
+    conn.commit()
+    conn.close()
+
+    stale = q.list_stale_pending(older_than_seconds=120, now=time.time())
+    assert not any(r["task_id"] == "prog-1" for r in stale)


### PR DESCRIPTION
## Summary
- **#133 Token auto-clear**: `_pane_token_count()` parses Claude's token hint ("save Xk tokens"); `_pane_clear_context()` sends `/clear` before pushing a task when context exceeds threshold (default 200k, env: `AGENT_CREW_TOKEN_CLEAR_THRESHOLD`)
- **#134 Gemini permission dismissal**: `_pane_dismiss_permission_prompt()` auto-selects "Allow for this session" when Gemini's execution approval prompt is visible — called in both the push path and watchdog tick so a frozen prompt never silently stalls a pane
- **#136 Stale pending re-dispatch**: watchdog tick now calls `list_stale_pending()` and re-fires `_try_push_next` for any role with pending tasks older than `AGENT_CREW_STALE_PENDING_SECONDS` (default 120s) — covers missed pushes when pane was busy at enqueue time

## Test plan
- [ ] 12 new unit tests in `test_pane_helpers.py` covering all three helpers and `list_stale_pending` queue method
- [ ] Full suite: 426 tests pass
- [ ] Manual: enqueue a task while pane is busy → verify watchdog re-dispatches after ~120s
- [ ] Manual: push task to high-context pane → verify `/clear` fires before task delivery

🤖 Generated with [Claude Code](https://claude.com/claude-code)