### PR TITLE
fix: escape stale agent process before re-launch in pane (#142)

### DIFF
--- a/src/agent_crew/setup.py
+++ b/src/agent_crew/setup.py
@@ -86,6 +86,16 @@ def start_agents_in_panes(
     for agent, target in zip(agents, pane_targets):
         wt_path = worktrees.get(agent) if worktrees else None
         cmd = _get_agent_cmd(agent, wt_path)
+        # #142: ensure the pane is at a shell prompt before launching.
+        # If an old agent process (e.g. gemini without --approval-mode yolo) is
+        # still running, send-keys -l feeds the cmd as chat input instead of
+        # executing it in the shell. Ctrl+C interrupts any interactive process;
+        # 'q' + Enter covers CLIs that catch Ctrl+C and present a quit prompt.
+        # Safe on fresh panes: Ctrl+C on an idle shell is a no-op.
+        subprocess.run(["tmux", "send-keys", "-t", target, "C-c"], capture_output=True)
+        time.sleep(0.3)
+        subprocess.run(["tmux", "send-keys", "-t", target, "q", "Enter"], capture_output=True)
+        time.sleep(0.3)
         _send_literal_text(target, cmd)
         _send_enter(target)
         if agent == "codex":

--- a/tests/unit/test_setup.py
+++ b/tests/unit/test_setup.py
@@ -108,15 +108,18 @@ def test_u_se08_start_agents_in_panes_uses_literal_send_keys():
          patch("agent_crew.setup.time.sleep"):
         start_agents_in_panes("crew_proj", ["claude"])
 
-    # 2 calls per agent (launch command + Enter); no kickoff prompt
-    assert mock_run.call_count == 2
-    launch_args = mock_run.call_args_list[0][0][0]
-    enter_args = mock_run.call_args_list[1][0][0]
-    # literal send for the launch command
-    assert "-l" in launch_args
-    assert "claude" in launch_args[-1]
-    # Enter send to submit launch
-    assert "Enter" in enter_args
+    # 4 calls per agent: C-c escape, q+Enter escape, launch cmd, Enter (#142)
+    assert mock_run.call_count == 4
+    all_args = [call[0][0] for call in mock_run.call_args_list]
+    # Escape sequence: first two calls send C-c and then q/Enter
+    assert any("C-c" in " ".join(a) for a in all_args), "Ctrl+C escape not sent"
+    assert any("q" in a for a in all_args), "q escape not sent"
+    # Launch cmd: literal send with agent cmd
+    literal_calls = [a for a in all_args if "-l" in a]
+    assert literal_calls, "no literal send found"
+    assert any("claude" in " ".join(a) for a in literal_calls)
+    # Enter to submit launch
+    assert any("Enter" in a for a in all_args)
     # Must NOT send any prompt text that references the AGENT_CREW TASK block
     for call in mock_run.call_args_list:
         args = call[0][0]


### PR DESCRIPTION
## Summary
- **Root cause (#142)**: `start_agents_in_panes` sends the agent launch command directly to the pane with `send-keys -l`. If an existing agent process (gemini without `--approval-mode yolo`) is still running, the command gets interpreted as chat input instead of executed in the shell — gemini launches without yolo flags, causing permission prompts on every shell command.
- **Fix**: Before sending each agent's launch command, send `C-c` (interrupt any running process) and `q`+`Enter` (exit interactive quit prompts). Both are no-ops on a fresh idle shell, so there is no regression on the normal teardown+setup flow.

## Reproduction
```bash
crew teardown agent_council && crew setup agent_council
# gemini pane: check /proc/<pid>/cmdline — flag missing without this fix
```

## Test plan
- [ ] Updated `test_u_se08` to assert the new 4-call sequence (C-c + q/Enter escape + launch + Enter)
- [ ] Full suite: 414 pass
- [ ] Manual: `crew teardown agent_council && crew setup agent_council` → verify gemini process has `--approval-mode yolo` in cmdline

🤖 Generated with [Claude Code](https://claude.com/claude-code)