### PR TITLE
fix(#150-155): stale cancel, usage-limit reroute, dispatch grace, GET /tasks status

### DIFF
--- a/src/agent_crew/cli.py
+++ b/src/agent_crew/cli.py
@@ -703,10 +703,86 @@ def status(project: str, base: str, preview: int):
             click.echo(f"  In progress: {role_running}")
 
 
+@crew.group("task")
+def task_group():
+    """Manage individual tasks in the queue."""
+
+
+@task_group.command("cancel")
+@click.argument("task_id")
+@click.option("--project", default="", help="Project name (reads DB from state)")
+@click.option("--base", default=_DEFAULT_BASE, show_default=True)
+@click.option("--db", default="", help="SQLite DB path (standalone)")
+def task_cancel(task_id: str, project: str, base: str, db: str):
+    """Cancel TASK_ID (marks as cancelled, orphans dependents)."""
+    from agent_crew.queue import TaskQueue
+    if not db:
+        if not project:
+            detected = _auto_detect_project(base)
+            if not detected:
+                raise click.ClickException("--db or --project is required")
+            project = detected
+        state = _read_state(base, project)
+        if state is None:
+            raise click.ClickException(f"project {project!r} not found")
+        db = state["db"]
+    TaskQueue(db).cancel(task_id)
+    click.echo(f"Cancelled: {task_id}")
+
+
+@task_group.command("expire-stale")
+@click.option("--project", default="", help="Project name")
+@click.option("--base", default=_DEFAULT_BASE, show_default=True)
+@click.option("--db", default="", help="SQLite DB path (standalone)")
+@click.option("--older-than", default=600, type=int, show_default=True,
+              help="Cancel in_progress tasks idle longer than N seconds")
+@click.option("--dry-run", is_flag=True, help="Print which tasks would be cancelled, but don't cancel")
+def task_expire_stale(project: str, base: str, db: str, older_than: int, dry_run: bool):
+    """Cancel stale in_progress tasks (idle > --older-than seconds)."""
+    import time as _t
+    from agent_crew.queue import TaskQueue
+    if not db:
+        if not project:
+            detected = _auto_detect_project(base)
+            if not detected:
+                raise click.ClickException("--db or --project is required")
+            project = detected
+        state = _read_state(base, project)
+        if state is None:
+            raise click.ClickException(f"project {project!r} not found")
+        db = state["db"]
+    q = TaskQueue(db)
+    if dry_run:
+        cutoff = _t.time() - older_than
+        import sqlite3 as _sq
+        conn = _sq.connect(db)
+        conn.row_factory = _sq.Row
+        rows = conn.execute(
+            "SELECT task_id, task_type, last_activity_at FROM tasks "
+            "WHERE status = 'in_progress' AND last_activity_at < ?", (cutoff,)
+        ).fetchall()
+        conn.close()
+        if not rows:
+            click.echo("No stale tasks found.")
+        for r in rows:
+            idle = int(_t.time() - (r["last_activity_at"] or 0))
+            click.echo(f"  would cancel: {r['task_id']} ({r['task_type']}, idle {idle}s)")
+        return
+    cancelled = q.expire_stale(older_than_seconds=float(older_than))
+    if cancelled:
+        click.echo(f"Cancelled {len(cancelled)} stale task(s): {', '.join(cancelled)}")
+    else:
+        click.echo("No stale tasks found.")
+
+
 @crew.command()
 @click.argument("project")
 @click.option("--base", default=_DEFAULT_BASE, show_default=True)
-def recover(project: str, base: str):
+@click.option("--reset-stale", is_flag=True,
+              help="Also cancel in_progress tasks idle > --stale-seconds")
+@click.option("--stale-seconds", default=600, type=int, show_default=True,
+              help="Idle threshold for --reset-stale")
+def recover(project: str, base: str, reset_stale: bool, stale_seconds: int):
     """Recover a crashed PROJECT: restart server and recreate tmux panes."""
     state = _read_state(base, project)
     if state is None:
@@ -909,6 +985,14 @@ def recover(project: str, base: str):
         click.echo(f"Recovered: {', '.join(recovered)}")
     else:
         click.echo("Nothing to recover: server and tmux already running.")
+
+    if reset_stale:
+        from agent_crew.queue import TaskQueue
+        cancelled = TaskQueue(db_file).expire_stale(older_than_seconds=float(stale_seconds))
+        if cancelled:
+            click.echo(f"Reset stale: cancelled {len(cancelled)} task(s): {', '.join(cancelled)}")
+        else:
+            click.echo(f"Reset stale: no in_progress tasks older than {stale_seconds}s.")
 
 
 @crew.command()

--- a/src/agent_crew/protocol.py
+++ b/src/agent_crew/protocol.py
@@ -19,6 +19,7 @@ class TaskRequest:
     priority: int = 3
     context: dict = field(default_factory=dict)
     project: str = ""  # owner/name form, e.g. "org/myrepo". Used to detect cross-project routing.
+    status: str = "pending"  # DB status; populated by list_tasks, not stored on enqueue
 
     def __post_init__(self):
         if self.task_type not in _VALID_TASK_TYPES:

--- a/src/agent_crew/queue.py
+++ b/src/agent_crew/queue.py
@@ -298,6 +298,28 @@ class TaskQueue:
         finally:
             conn.close()
 
+    def expire_stale(self, older_than_seconds: float = 600.0) -> List[str]:
+        """Cancel in_progress tasks whose last_activity_at is older than
+        ``older_than_seconds``. Returns list of cancelled task_ids."""
+        cutoff = time.time() - older_than_seconds
+        conn = self._connect()
+        try:
+            rows = conn.execute(
+                "SELECT task_id FROM tasks WHERE status = 'in_progress' AND last_activity_at < ?",
+                (cutoff,),
+            ).fetchall()
+            task_ids = [r["task_id"] for r in rows]
+            if task_ids:
+                placeholders = ",".join("?" * len(task_ids))
+                conn.execute(
+                    f"UPDATE tasks SET status = 'cancelled' WHERE task_id IN ({placeholders})",
+                    task_ids,
+                )
+                conn.commit()
+            return task_ids
+        finally:
+            conn.close()
+
     def list_orphaned(self) -> List[TaskRequest]:
         """Return all tasks with status='orphaned'."""
         conn = self._connect()
@@ -464,6 +486,7 @@ class TaskQueue:
                     priority=r["priority"],
                     context=json.loads(r["context"]),
                     project=r["project"] if r["project"] else "",
+                    status=r["status"],
                 )
                 for r in rows
             ]

--- a/src/agent_crew/server.py
+++ b/src/agent_crew/server.py
@@ -15,6 +15,7 @@ from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 
 from agent_crew.anomaly import check_wrong_repo
+from agent_crew.fallback import is_rate_limit_error
 from agent_crew.loop import _resolve_verdict
 from agent_crew.pipeline import (
     auto_enqueue_review as _pipeline_auto_enqueue_review,
@@ -188,6 +189,21 @@ def _pane_is_thinking(capture: str) -> bool:
     """
     tail = "\n".join(capture.splitlines()[-_THINKING_TAIL_LINES:])
     return bool(_THINKING_RE.search(tail))
+
+
+def _pane_has_usage_limit(pane_id: str) -> bool:
+    """Return True when the pane capture contains a rate-limit / usage-limit
+    message, meaning the agent is blocked and can't accept new tasks (#151)."""
+    try:
+        r = subprocess.run(
+            ["tmux", "capture-pane", "-p", "-t", pane_id],
+            capture_output=True, text=True,
+        )
+        if r.returncode != 0:
+            return False
+        return is_rate_limit_error(r.stdout)
+    except Exception:
+        return False
 
 
 def _pane_is_busy(pane_id: str) -> bool:
@@ -633,6 +649,41 @@ def create_app(
                         f"task_id={task.task_id} — continuing with dispatch"
                     )
 
+        # #151: if target pane shows a usage-limit message, immediately reroute
+        # via fallback rather than pushing into a blocked agent.
+        if _pane_has_usage_limit(pane_id):
+            blocked_agent = next(
+                (k for k, v in (pane_map or {}).items() if v == pane_id and k in ("claude", "codex", "gemini")),
+                None,
+            )
+            logger.warning(
+                f"_try_push_next: pane {pane_id} shows usage-limit — "
+                f"skipping push, routing task {task.task_id} to fallback "
+                f"(blocked_agent={blocked_agent})"
+            )
+            usage_limit_summary = (
+                f"usage limit detected on pane {pane_id}"
+                + (f" (agent={blocked_agent})" if blocked_agent else "")
+            )
+            task_type_for_fb = _ROLE_TO_TYPE.get(role)
+            if task_type_for_fb:
+                fb_result = TaskResult(
+                    task_id=task.task_id,
+                    status="failed",
+                    summary=usage_limit_summary,
+                    verdict=None,
+                    findings=[],
+                    pr_number=None,
+                )
+                q().force_fail(task.task_id, usage_limit_summary)
+                try:
+                    _auto_fallback_failed_task(task.task_id, fb_result, task_type_for_fb)
+                except Exception:
+                    logger.exception(f"_try_push_next: fallback failed for usage-limited task {task.task_id}")
+            else:
+                q().requeue(task.task_id)
+            return
+
         logger.info(f"_try_push_next: dequeued task_id={task.task_id}, calling push_fn")
         # #133: clear oversized context before pushing so claude doesn't stall.
         tok = _pane_token_count(pane_id)
@@ -738,7 +789,13 @@ def create_app(
                 continue
 
             idle_for = now - (row["last_activity_at"] or now)
-            if idle_for >= timeout_seconds:
+            # #152: require at least one reminder before timing out. This
+            # prevents a newly-dispatched task (whose pane was occupied by
+            # a prior task) from being force-failed before it ever had a
+            # chance to be picked up. A task that has never been reminded
+            # has not yet had idle_for ≥ reminder_seconds confirmed, so we
+            # treat it as still within its dispatch-grace window.
+            if idle_for >= timeout_seconds and task_id in reminded_task_ids:
                 summary = (
                     f"watchdog timeout: pane idle {idle_for:.0f}s without "
                     f"sign of activity (threshold {timeout_seconds:.0f}s)"
@@ -1085,6 +1142,13 @@ def create_app(
     def cancel_task(task_id: str):
         q().cancel(task_id)
         return {"status": "cancelled"}
+
+    @app.post("/tasks/expire-stale", status_code=200)
+    def expire_stale_tasks(older_than: float = 600.0):
+        """Cancel in_progress tasks idle longer than ``older_than`` seconds.
+        Returns list of cancelled task_ids."""
+        cancelled = q().expire_stale(older_than_seconds=older_than)
+        return {"cancelled": cancelled}
 
     @app.post("/gates", status_code=201)
     def post_gate(gate: GateRequest):

--- a/tests/unit/test_server_watchdog.py
+++ b/tests/unit/test_server_watchdog.py
@@ -166,6 +166,7 @@ def test_u_wd04_reminder_dedupe_resets_after_busy(tmp_db):
 
 
 # U-WD05: Idle ≥ timeout → task auto-failed, role released, queued task pushed.
+# Timeout requires a prior reminder (#152: dispatch-grace window).
 def test_u_wd05_idle_past_timeout_auto_fails_and_pushes_next(tmp_db):
     busy = _PaneState()
     push = _RecordingPush()
@@ -181,7 +182,9 @@ def test_u_wd05_idle_past_timeout_auto_fails_and_pushes_next(tmp_db):
         assert len(push.calls) == 1, "second task should have been queued"
 
         TaskQueue(tmp_db).bump_activity("t-stuck", ts=1000.0)
-        # idle_for = 1500s → past timeout (900s).
+        # First: fire reminder tick (idle_for=400s ≥ reminder=300s).
+        app.state.watchdog_tick(now=1400.0)
+        # Then: fire timeout tick (idle_for=1500s ≥ timeout=900s).
         result = app.state.watchdog_tick(now=2500.0)
 
     assert result["timed_out"] == ["t-stuck"]
@@ -190,9 +193,10 @@ def test_u_wd05_idle_past_timeout_auto_fails_and_pushes_next(tmp_db):
     all_with_status = TaskQueue(tmp_db).list_all_with_status()
     stuck_status = next(r["status"] for r in all_with_status if r["task_id"] == "t-stuck")
     assert stuck_status == "failed"
-    # Next queued task pushed to the now-idle implementer pane.
-    assert len(push.calls) == 2
-    assert "t-next" in push.calls[1][1]
+    # push.calls: initial t-stuck + reminder nudge + t-next dispatch
+    # (#152: timeout requires a prior reminder, so reminder fires at tick 1)
+    assert len(push.calls) == 3
+    assert "t-next" in push.calls[2][1]
 
 
 # U-WD06: discuss tasks → watchdog uses context.agent for pane resolution.
@@ -292,7 +296,10 @@ def test_u_wd08_timeout_sends_ctrl_c_to_pane(tmp_db, monkeypatch):
     with TestClient(app) as client:
         client.post("/tasks", json=_task_payload("t-hung"))
         TaskQueue(tmp_db).bump_activity("t-hung", ts=1000.0)
+        # First tick: send reminder (idle_for=400s ≥ reminder=300s).
+        app.state.watchdog_tick(now=1400.0)
         monkeypatch.setattr("agent_crew.server.subprocess.run", fake_run)
+        # Second tick: timeout fires (idle_for=1500s ≥ timeout=900s).
         app.state.watchdog_tick(now=2500.0)
 
     # Must have sent C-c to the hung pane

--- a/tests/unit/test_stream_timeout_recovery.py
+++ b/tests/unit/test_stream_timeout_recovery.py
@@ -128,8 +128,11 @@ def test_watchdog_timeout_routes_to_next_agent_via_fallback(tmp_db):
     )
     with TestClient(app) as client:
         client.post("/tasks", json=_task_payload("impl-stream"))
-        # Force last_activity_at to a known value, then tick past timeout.
+        # Force last_activity_at to a known value.
         TaskQueue(tmp_db).bump_activity("impl-stream", ts=1000.0)
+        # First tick: fire reminder (idle_for=400s ≥ reminder=300s, #152).
+        app.state.watchdog_tick(now=1400.0)
+        # Second tick: fire timeout (idle_for=1500s ≥ timeout=900s).
         result = app.state.watchdog_tick(now=2500.0)
 
     assert result["timed_out"] == ["impl-stream"]


### PR DESCRIPTION
## Summary
- **#150 + #155**: `crew task cancel <id>`, `crew task expire-stale [--dry-run]`, `crew recover --reset-stale` — stale in_progress cleanup without touching SQLite directly
- **#151**: `_pane_has_usage_limit()` — before every push, captures pane and checks for usage/rate-limit patterns. If found, force-fails and routes to next fallback agent immediately
- **#152**: watchdog timeout now requires a prior reminder (`task_id in reminded_task_ids`). Newly dispatched tasks get a dispatch-grace window of at least `reminder_seconds` before force-fail
- **#154**: `TaskRequest.status` field added; `list_tasks()` populates from DB — `GET /tasks` now includes status

## Test plan
- [ ] `python -m pytest tests/unit/ -q` — 446 tests pass
- [ ] `crew task cancel <id>` — marks task cancelled
- [ ] `crew task expire-stale --dry-run` — shows stale tasks without touching DB
- [ ] `crew recover --reset-stale` — cleans stale records on recovery
- [ ] `GET /tasks` response includes `status` field
- [ ] Watchdog: idle task with no prior reminder → reminder fires first, then timeout

Closes #150, #151, #152, #154, #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)